### PR TITLE
Fix(ci): Ensure lowercase repository name in Docker image tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,6 +42,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set lowercase repository name
+        id: repo_lowercase
+        run: echo "name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
       - name: Build and push Backend image
         uses: docker/build-push-action@v5
         with:
@@ -49,7 +53,7 @@ jobs:
           file: ./backend/Dockerfile
           push: true
           platforms: linux/arm64, linux/amd64
-          tags: ghcr.io/${{ github.repository }}/suna-backend:${{ steps.get_tag_name.outputs.branch }}
+          tags: ghcr.io/${{ steps.repo_lowercase.outputs.name }}/suna-backend:${{ steps.get_tag_name.outputs.branch }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Updates the .github/workflows/docker-build.yml workflow to address a build failure caused by uppercase characters in the repository name part of the Docker image tag.

The error "ERROR: invalid tag "ghcr.io/Arx88/Neura/suna-backend:latest": repository name must be lowercase" occurred because `github.repository` (e.g., "Arx88/Neura") was used directly in the tag.

This commit introduces a new step that converts `github.repository` to lowercase using `tr '[:upper:]' '[:lower:]'`. The resulting lowercase string is then used to construct the Docker image tag, ensuring compatibility with Docker's naming conventions (e.g., `ghcr.io/arx88/neura/suna-backend:latest`).