### PR TITLE
Fix: Set OpenRouter API key as environment variable for litellm

### DIFF
--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -42,9 +42,25 @@ def setup_api_keys() -> None:
     for provider in providers:
         key = getattr(config, f'{provider}_API_KEY')
         if key:
-            logger.debug(f"API key set for provider: {provider}")
+            logger.debug(f"API key found in config for provider: {provider}")
         else:
-            logger.warning(f"No API key found for provider: {provider}")
+            logger.warning(f"No API key found in config for provider: {provider}")
+
+    api_key_providers = {
+        "OPENAI": "OPENAI_API_KEY",
+        "ANTHROPIC": "ANTHROPIC_API_KEY",
+        "GROQ": "GROQ_API_KEY",
+        "OPENROUTER": "OPENROUTER_API_KEY"
+        # OLLAMA is handled differently, so it's omitted here
+    }
+
+    for provider_name, env_var_name in api_key_providers.items():
+        api_key = getattr(config, env_var_name, None)
+        if api_key:
+            os.environ[env_var_name] = api_key
+            logger.debug(f"Set {env_var_name} environment variable.")
+        else:
+            logger.warning(f"No {env_var_name} found in config to set as environment variable.")
 
     # Set up OpenRouter API base if not already set
     if config.OPENROUTER_API_KEY and config.OPENROUTER_API_BASE:


### PR DESCRIPTION
Previously, litellm would fail with an AuthenticationError when trying to use OpenRouter models because the OPENROUTER_API_KEY was not available in the environment in a way litellm could automatically detect.

This change modifies the `setup_api_keys` function in `backend/services/llm.py` to explicitly set `os.environ['OPENROUTER_API_KEY']` if `config.OPENROUTER_API_KEY` is present.

Additionally, similar environment variable settings were added for OPENAI_API_KEY, ANTHROPIC_API_KEY, and GROQ_API_KEY to ensure consistent API key handling for litellm across these providers and to proactively prevent similar issues.