### PR TITLE
Fix: Prevent duplicate tasks on deletion by invalidating queries

### DIFF
--- a/frontend/src/hooks/react-query/sidebar/use-project-mutations.ts
+++ b/frontend/src/hooks/react-query/sidebar/use-project-mutations.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createMutationHook } from '@/hooks/use-query';
 import { 
   createProject, 
@@ -9,6 +10,7 @@ import {
 } from '@/lib/api';
 import { toast } from 'sonner';
 import { projectKeys } from './keys';
+import { handleApiError } from '@/lib/error-handler';
 
 export const useCreateProject = createMutationHook(
   (data: { name: string; description: string; accountId?: string }) => 
@@ -38,15 +40,21 @@ export const useUpdateProject = createMutationHook(
   }
 );
 
-export const useDeleteProject = createMutationHook(
-  ({ projectId }: { projectId: string }) => deleteProject(projectId),
-  {
-    onSuccess: () => {
+export const useDeleteProject = () => {
+  const queryClient = useQueryClient();
+  
+  return useMutation({
+    mutationFn: ({ projectId }: { projectId: string }) => deleteProject(projectId),
+    onSuccess: (data: unknown, variables: { projectId: string }, context: unknown) => {
       toast.success('Project deleted successfully');
+      queryClient.invalidateQueries({ queryKey: projectKeys.all });
     },
-    errorContext: {
-      operation: 'delete project',
-      resource: 'project'
+    onError: (error: Error, variables: { projectId: string }, context: unknown) => {
+      const errorContext = { 
+        operation: 'delete project', 
+        resource: `project (ID: ${variables.projectId})` // Resource ID included for better error tracking
+      };
+      handleApiError(error, errorContext);
     }
-  }
-); 
+  });
+};


### PR DESCRIPTION
You reported that deleting a task (project) resulted in duplicates appearing in the task list.

This issue was traced to the frontend not properly updating its cache after a successful deletion. The `useDeleteProject` hook was modified to:
1. Directly use `useMutation` from React Query for more granular control.
2. Call `queryClient.invalidateQueries({ queryKey: projectKeys.all })` in the `onSuccess` handler. This ensures that all queries related to projects are marked as stale and refetched, updating the UI with the correct list of projects.
3. Explicitly use `handleApiError` for error handling consistency.

This change ensures that the project list is correctly updated in the UI after a project is deleted.