### PR TITLE
feat: Implement dynamic LLM selection from UI

### DIFF
--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -221,31 +221,30 @@ async def start_agent(
             # This specific check should probably remain as it's a precondition for the API itself
             raise HTTPException(status_code=500, detail="Agent API not initialized with instance ID")
 
-        # Nueva lógica de determinación de model_name
+        # New model selection logic (UI > Server Config > Hardcoded Default)
         server_configured_model = config.MODEL_TO_USE
-        model_name_from_request = body.model_name
+        model_name_from_request = body.model_name # Specific to start_agent
         final_model_name_to_use = None
 
-        if config.OLLAMA_API_BASE and config.OLLAMA_API_BASE.strip() and server_configured_model and server_configured_model.strip():
-            logger.info(f"OLLAMA_API_BASE ('{config.OLLAMA_API_BASE}') and MODEL_TO_USE ('{server_configured_model}') are set in server config. Prioritizing server config for main agent model.")
-            final_model_name_to_use = server_configured_model
-            if model_name_from_request:
-                logger.info(f"Ignoring 'model_name: {model_name_from_request}' from request body due to server-side OLLAMA configuration priority.")
-        elif model_name_from_request:
+        if model_name_from_request and model_name_from_request.strip():
             logger.info(f"Using 'model_name: {model_name_from_request}' from request body.")
             final_model_name_to_use = model_name_from_request
-        else:
-            logger.info(f"No model_name in request body, using MODEL_TO_USE ('{server_configured_model}') from server config.")
+        elif server_configured_model and server_configured_model.strip():
+            logger.info(f"No model_name in request body or it was empty, using MODEL_TO_USE ('{server_configured_model}') from server config.")
             final_model_name_to_use = server_configured_model
+        else:
+            default_fallback_model = "gpt-3.5-turbo" 
+            logger.warning(f"No model specified in UI or server config. Falling back to hardcoded default: '{default_fallback_model}'.")
+            final_model_name_to_use = default_fallback_model
         
         logger.info(f"Effective model name before alias resolution: {final_model_name_to_use}")
 
-        # Log the model name after alias resolution
-        resolved_model = MODEL_NAME_ALIASES.get(final_model_name_to_use, final_model_name_to_use)
-        model_name = resolved_model # Esta es la variable que se usará en el resto de la función
+        # Alias resolution
+        # The variable `model_name` will be used for subsequent logic like Ollama prefixing and the actual LLM call.
+        model_name = MODEL_NAME_ALIASES.get(final_model_name_to_use, final_model_name_to_use)
         logger.info(f"Model name after alias resolution: {model_name}")
 
-        # New logic to insert for Ollama model prefixing
+        # Ollama prefixing logic (existing, but now uses the model_name derived from new selection logic)
         if config.OLLAMA_API_BASE and config.OLLAMA_API_BASE.strip():
             has_known_provider_prefix = any(model_name.startswith(p) for p in ["openrouter/", "openai/", "anthropic/", "bedrock/", "ollama/"])
             if not has_known_provider_prefix:
@@ -647,32 +646,30 @@ async def initiate_agent_with_files(
     if not instance_id:
         raise HTTPException(status_code=500, detail="Agent API not initialized with instance ID")
 
-    # Nueva lógica de determinación de model_name
+    # New model selection logic (UI > Server Config > Hardcoded Default)
     server_configured_model = config.MODEL_TO_USE
-    # model_name_from_request se obtiene del parámetro de la función 'model_name'
-    model_name_from_request = model_name 
+    model_name_from_request = model_name # Specific to initiate_agent_with_files (from Form input)
     final_model_name_to_use = None
 
-    if config.OLLAMA_API_BASE and config.OLLAMA_API_BASE.strip() and server_configured_model and server_configured_model.strip():
-        logger.info(f"OLLAMA_API_BASE ('{config.OLLAMA_API_BASE}') and MODEL_TO_USE ('{server_configured_model}') are set in server config. Prioritizing server config for main agent model.")
-        final_model_name_to_use = server_configured_model
-        if model_name_from_request:
-            logger.info(f"Ignoring 'model_name: {model_name_from_request}' from request (Form value) due to server-side OLLAMA configuration priority.")
-    elif model_name_from_request:
+    if model_name_from_request and model_name_from_request.strip():
         logger.info(f"Using 'model_name: {model_name_from_request}' from request (Form value).")
         final_model_name_to_use = model_name_from_request
-    else:
-        logger.info(f"No model_name in request (Form value), using MODEL_TO_USE ('{server_configured_model}') from server config.")
+    elif server_configured_model and server_configured_model.strip():
+        logger.info(f"No model_name in request (Form value) or it was empty, using MODEL_TO_USE ('{server_configured_model}') from server config.")
         final_model_name_to_use = server_configured_model
-
+    else:
+        default_fallback_model = "gpt-3.5-turbo"
+        logger.warning(f"No model specified in UI or server config (Form value). Falling back to hardcoded default: '{default_fallback_model}'.")
+        final_model_name_to_use = default_fallback_model
+        
     logger.info(f"Effective model name before alias resolution: {final_model_name_to_use}")
-    
-    # Log the model name after alias resolution
-    resolved_model = MODEL_NAME_ALIASES.get(final_model_name_to_use, final_model_name_to_use)
-    model_name = resolved_model # Esta es la variable que se usará en el resto de la función
+
+    # Alias resolution
+    # The variable `model_name` (re-assigned here from the function parameter) will be used for subsequent logic.
+    model_name = MODEL_NAME_ALIASES.get(final_model_name_to_use, final_model_name_to_use)
     logger.info(f"Model name after alias resolution: {model_name}")
     
-    # New logic to insert for Ollama model prefixing
+    # Ollama prefixing logic (existing, but now uses the model_name derived from new selection logic)
     if config.OLLAMA_API_BASE and config.OLLAMA_API_BASE.strip():
         has_known_provider_prefix = any(model_name.startswith(p) for p in ["openrouter/", "openai/", "anthropic/", "bedrock/", "ollama/"])
         if not has_known_provider_prefix:

--- a/backend/api.py
+++ b/backend/api.py
@@ -13,6 +13,10 @@ from utils.logger import logger
 import uuid
 import time
 from collections import OrderedDict
+from fastapi import APIRouter, Depends, HTTPException # Added APIRouter, Depends, HTTPException
+from typing import List, Dict, Optional # Added List, Dict, Optional
+from pydantic import BaseModel # Added BaseModel
+import litellm # Added litellm
 
 # Import the agent API module
 from agent import api as agent_api
@@ -135,6 +139,143 @@ app.include_router(billing_api.router, prefix="/api")
 
 # Include the transcription router with a prefix
 app.include_router(transcription_api.router, prefix="/api")
+
+# --- LLM Models API ---
+
+class ModelInfo(BaseModel):
+    id: str
+    name: str
+
+class ProviderModels(BaseModel):
+    configured: bool
+    models: List[ModelInfo]
+
+class AllModelsResponse(BaseModel):
+    ollama: Optional[ProviderModels] = None
+    openai: ProviderModels
+    anthropic: ProviderModels
+    openrouter: ProviderModels
+    groq: ProviderModels
+    bedrock: ProviderModels
+
+llm_api_router = APIRouter()
+
+PREDEFINED_MODELS = {
+    "openai": {
+        "config_key_env": "OPENAI_API_KEY", # Store env var name
+        "models": [
+            {"id": "gpt-4o-mini", "name": "GPT-4o Mini"},
+            {"id": "gpt-4-turbo", "name": "GPT-4 Turbo"},
+            {"id": "gpt-3.5-turbo", "name": "GPT-3.5 Turbo"},
+        ]
+    },
+    "anthropic": {
+        "config_key_env": "ANTHROPIC_API_KEY",
+        "models": [
+            {"id": "claude-3-opus-20240229", "name": "Claude 3 Opus"},
+            {"id": "claude-3-sonnet-20240229", "name": "Claude 3 Sonnet"},
+            {"id": "claude-3-haiku-20240307", "name": "Claude 3 Haiku"},
+        ]
+    },
+    "openrouter": {
+        "config_key_env": "OPENROUTER_API_KEY",
+        "models": [
+            {"id": "openrouter/anthropic/claude-3-opus", "name": "Claude 3 Opus (OpenRouter)"},
+            {"id": "openrouter/google/gemini-pro-1.5", "name": "Gemini Pro 1.5 (OpenRouter)"},
+            {"id": "openrouter/openai/gpt-4o", "name": "GPT-4o (OpenRouter)"},
+            {"id": "openrouter/mistralai/mistral-large", "name": "Mistral Large (OpenRouter)"},
+            {"id": "openrouter/meta-llama/llama-3-70b-instruct", "name": "Llama 3 70B (OpenRouter)"}
+        ]
+    },
+    "groq": {
+        "config_key_env": "GROQ_API_KEY",
+        "models": [
+            {"id": "llama3-8b-8192", "name": "Llama3 8B (Groq)"},
+            {"id": "mixtral-8x7b-32768", "name": "Mixtral 8x7B (Groq)"},
+            {"id": "gemma-7b-it", "name": "Gemma 7B (Groq)"}
+        ]
+    },
+    "bedrock": {
+        # For Bedrock, configuration depends on multiple AWS keys
+        "is_configured_check": lambda: bool(config.AWS_ACCESS_KEY_ID and config.AWS_SECRET_ACCESS_KEY and config.AWS_REGION_NAME),
+        "models": [
+            {"id": "bedrock/anthropic.claude-3-opus-v1:0", "name": "Claude 3 Opus (Bedrock)"},
+            {"id": "bedrock/anthropic.claude-3-sonnet-v1:0", "name": "Claude 3 Sonnet (Bedrock)"},
+            {"id": "bedrock/amazon.titan-text-express-v1", "name": "Titan Text Express (Bedrock)"}
+        ]
+    }
+}
+
+@llm_api_router.get("/llm/all-models", response_model=AllModelsResponse)
+async def get_all_llm_models():
+    logger.debug("Fetching all LLM models")
+    
+    # Ollama
+    ollama_provider: Optional[ProviderModels] = None
+    if config.OLLAMA_API_BASE:
+        ollama_models_list = []
+        try:
+            logger.info(f"Attempting to fetch Ollama models from {config.OLLAMA_API_BASE}")
+            ollama_raw_models = await litellm.aget_model_list(base_url=config.OLLAMA_API_BASE, api_key="ollama") # Added await and api_key
+            if ollama_raw_models:
+                for model_data in ollama_raw_models:
+                    if isinstance(model_data, dict):
+                        model_id = model_data.get("id") or model_data.get("name") or model_data.get("model") # More robust id fetching
+                        model_name = model_data.get("name") or model_id # Fallback name
+                    elif isinstance(model_data, str):
+                        model_id = model_data
+                        model_name = model_data
+                    else:
+                        logger.warning(f"Unexpected model data format from Ollama: {model_data}")
+                        continue
+                    
+                    if model_id:
+                        # Ensure "ollama/" prefix, handling cases where it might already exist (though unlikely from get_model_list)
+                        full_id = f"ollama/{model_id}" if not model_id.startswith("ollama/") else model_id
+                        # Derive a user-friendly name if not sufficiently descriptive
+                        simple_name = model_id.split('/')[-1] # Get the part after "ollama/" if present
+                        display_name = f"{simple_name.replace('-', ' ').title()} (Local)" if model_name == model_id else f"{model_name} (Local)"
+
+                        ollama_models_list.append(ModelInfo(id=full_id, name=display_name))
+                logger.info(f"Successfully fetched {len(ollama_models_list)} models from Ollama.")
+            else:
+                logger.info("No models returned from Ollama.")
+            ollama_provider = ProviderModels(configured=True, models=ollama_models_list)
+        except Exception as e:
+            logger.error(f"Error fetching Ollama models from {config.OLLAMA_API_BASE}: {e}")
+            # OLLAMA_API_BASE is configured, but fetching failed
+            ollama_provider = ProviderModels(configured=True, models=[]) 
+    else:
+        logger.info("Ollama API base URL not configured.")
+        ollama_provider = ProviderModels(configured=False, models=[])
+
+    # Cloud Providers
+    provider_responses: Dict[str, ProviderModels] = {}
+    for provider_key, details in PREDEFINED_MODELS.items():
+        is_configured = False
+        if "is_configured_check" in details: # For Bedrock
+            is_configured = details["is_configured_check"]()
+        elif "config_key_env" in details: # For others
+            # Check if the attribute exists on config and is not None/empty
+            config_val = getattr(config, details["config_key_env"], None)
+            is_configured = bool(config_val) 
+        
+        models = [ModelInfo(**m) for m in details["models"]]
+        provider_responses[provider_key] = ProviderModels(configured=is_configured, models=models)
+        logger.debug(f"Provider {provider_key} configured: {is_configured}, Models: {len(models)}")
+
+    return AllModelsResponse(
+        ollama=ollama_provider,
+        openai=provider_responses["openai"],
+        anthropic=provider_responses["anthropic"],
+        openrouter=provider_responses["openrouter"],
+        groq=provider_responses["groq"],
+        bedrock=provider_responses["bedrock"],
+    )
+
+# Include the LLM API router
+app.include_router(llm_api_router, prefix="/api")
+
 
 @app.get("/api/health")
 async def health_check():

--- a/frontend/src/components/thread/chat-input/_use-model-selection.ts
+++ b/frontend/src/components/thread/chat-input/_use-model-selection.ts
@@ -3,7 +3,9 @@
 import { useSubscription } from '@/hooks/react-query/subscriptions/use-subscriptions';
 import { useState, useEffect, useMemo } from 'react';
 import { isLocalMode } from '@/lib/config';
-import { useAvailableModels } from '@/hooks/react-query/subscriptions/use-model';
+// import { useAvailableModels } from '@/hooks/react-query/subscriptions/use-model'; // Replaced
+import { useAllLlmModels } from '@/hooks/react-query/subscriptions/use-model'; // Added
+import { AllLlmModelsResponse, ApiProviderModels, ApiModelInfo } from '@/lib/api'; // Added
 
 export const STORAGE_KEY_MODEL = 'suna-preferred-model';
 export const STORAGE_KEY_CUSTOM_MODELS = 'customModels';
@@ -20,6 +22,8 @@ export interface ModelOption {
   top?: boolean;
   isCustom?: boolean;
   priority?: number;
+  provider?: string; // Added
+  configured?: boolean; // Added
 }
 
 export interface CustomModel {
@@ -177,15 +181,15 @@ export const MODEL_TIERS = {
 };
 
 // Helper to check if a user can access a model based on subscription status
-export const canAccessModel = (
-  subscriptionStatus: SubscriptionStatus,
-  requiresSubscription: boolean,
-): boolean => {
-  if (isLocalMode()) {
-    return true;
-  }
-  return subscriptionStatus === 'active' || !requiresSubscription;
-};
+// export const canAccessModel = ( // Renamed and replaced
+//   subscriptionStatus: SubscriptionStatus,
+//   requiresSubscription: boolean,
+// ): boolean => {
+//   if (isLocalMode()) {
+//     return true;
+//   }
+//   return subscriptionStatus === 'active' || !requiresSubscription;
+// };
 
 // Helper to format a model name for display
 export const formatModelName = (name: string): string => {
@@ -239,9 +243,10 @@ export const useModelSelection = () => {
   const [customModels, setCustomModels] = useState<CustomModel[]>([]);
   
   const { data: subscriptionData } = useSubscription();
-  const { data: modelsData, isLoading: isLoadingModels } = useAvailableModels({
-    refetchOnMount: false,
-  });
+  // const { data: modelsData, isLoading: isLoadingModels } = useAvailableModels({ // Replaced
+  //   refetchOnMount: false,
+  // });
+  const { data: allModelsData, isLoading: isLoadingAllModels } = useAllLlmModels(); // Added
   
   const subscriptionStatus: SubscriptionStatus = subscriptionData?.status === 'active' 
     ? 'active' 
@@ -262,164 +267,256 @@ export const useModelSelection = () => {
 
   // Generate model options list with consistent structure
   const MODEL_OPTIONS = useMemo(() => {
-    let models = [];
-    
-    // Default models if API data not available
-    if (!modelsData?.models || isLoadingModels) {
-      models = [
+    const modelOptionsList: ModelOption[] = [];
+
+    if (isLoadingAllModels) {
+      // Return a minimal or empty list while loading, or a default loading state.
+      // For now, let's use the previous approach of default models if API is loading.
+      // This part can be refined later if a specific loading UI for models is needed.
+      return [
+        { 
+          id: DEFAULT_FREE_MODEL_ID, 
+          label: 'DeepSeek (Loading...)', 
+          requiresSubscription: false,
+          description: MODELS[DEFAULT_FREE_MODEL_ID]?.description || MODEL_TIERS.free.baseDescription,
+          priority: MODELS[DEFAULT_FREE_MODEL_ID]?.priority || 50,
+          provider: 'default',
+          configured: true,
+        },
+        { 
+          id: DEFAULT_PREMIUM_MODEL_ID, 
+          label: 'Claude Sonnet 4 (Loading...)', 
+          requiresSubscription: true, 
+          description: MODELS[DEFAULT_PREMIUM_MODEL_ID]?.description || MODEL_TIERS.premium.baseDescription,
+          priority: MODELS[DEFAULT_PREMIUM_MODEL_ID]?.priority || 100,
+          provider: 'default',
+          configured: true,
+        },
+      ];
+    }
+
+    if (allModelsData) {
+      // Define a preferred provider order for later sorting
+      const providerOrder = ["ollama", "openai", "anthropic", "openrouter", "groq", "bedrock", "custom"];
+
+      Object.entries(allModelsData).forEach(([providerKey, providerDetails]) => {
+        const currentProvider = providerDetails as ApiProviderModels | undefined; // Type assertion
+        if (currentProvider && currentProvider.models) {
+          currentProvider.models.forEach((apiModel: ApiModelInfo) => {
+            const modelMeta = MODELS[apiModel.id] || MODELS[apiModel.id.replace(/^openrouter\//, '')] || {}; // Check with and without openrouter prefix for MODELS match
+            
+            let reqSub = !['ollama', 'custom'].includes(providerKey); // Default based on provider type
+            // Override with specific tier info from MODELS constant if available
+            if (modelMeta.tier === 'free') reqSub = false;
+            if (modelMeta.tier === 'premium') reqSub = true;
+
+            modelOptionsList.push({
+              id: apiModel.id, // ID from backend is king
+              label: apiModel.name, // Name from backend is king
+              requiresSubscription: reqSub,
+              description: modelMeta.description || `Model from ${providerKey}`,
+              top: (modelMeta.priority || 0) >= 90,
+              priority: modelMeta.priority || 50, // Default priority
+              lowQuality: modelMeta.lowQuality || false,
+              recommended: modelMeta.recommended || false,
+              provider: providerKey,
+              configured: currentProvider.configured,
+              isCustom: false, // Will be set true for actual custom models later
+            });
+          });
+        }
+      });
+    } else if (!isLoadingAllModels) {
+      // Handle case where data is null and not loading (e.g., API error)
+      // Fallback to a minimal set of hardcoded models or show an error state.
+      // For now, using a similar default as loading state but without "(Loading...)"
+       modelOptionsList.push(
         { 
           id: DEFAULT_FREE_MODEL_ID, 
           label: 'DeepSeek', 
           requiresSubscription: false,
           description: MODELS[DEFAULT_FREE_MODEL_ID]?.description || MODEL_TIERS.free.baseDescription,
-          priority: MODELS[DEFAULT_FREE_MODEL_ID]?.priority || 50
+          priority: MODELS[DEFAULT_FREE_MODEL_ID]?.priority || 50,
+          provider: 'fallback',
+          configured: true,
         },
         { 
           id: DEFAULT_PREMIUM_MODEL_ID, 
           label: 'Claude Sonnet 4', 
           requiresSubscription: true, 
           description: MODELS[DEFAULT_PREMIUM_MODEL_ID]?.description || MODEL_TIERS.premium.baseDescription,
-          priority: MODELS[DEFAULT_PREMIUM_MODEL_ID]?.priority || 100
-        },
-      ];
-    } else {
-      // Process API-provided models
-      models = modelsData.models.map(model => {
-        const shortName = model.short_name || model.id;
-        const displayName = model.display_name || shortName;
-        
-        // Format the display label
-        let cleanLabel = displayName;
-        if (cleanLabel.includes('/')) {
-          cleanLabel = cleanLabel.split('/').pop() || cleanLabel;
+          priority: MODELS[DEFAULT_PREMIUM_MODEL_ID]?.priority || 100,
+          provider: 'fallback',
+          configured: true,
         }
-        
-        cleanLabel = cleanLabel
-          .replace(/-/g, ' ')
-          .split(' ')
-          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-          .join(' ');
-        
-        // Get model data from our central MODELS constant
-        const modelData = MODELS[shortName] || {};
-        const isPremium = model?.requires_subscription || modelData.tier === 'premium' || false;
-        
-        return {
-          id: shortName,
-          label: cleanLabel,
-          requiresSubscription: isPremium,
-          description: modelData.description || 
-            (isPremium ? MODEL_TIERS.premium.baseDescription : MODEL_TIERS.free.baseDescription),
-          top: modelData.priority >= 90, // Mark high-priority models as "top"
-          priority: modelData.priority || 0,
-          lowQuality: modelData.lowQuality || false,
-          recommended: modelData.recommended || false
-        };
-      });
+      );
     }
     
     // Add custom models if in local mode
     if (isLocalMode() && customModels.length > 0) {
-      const customModelOptions = customModels.map(model => ({
-        id: model.id,
-        label: model.label || formatModelName(model.id),
-        requiresSubscription: false,
-        description: MODEL_TIERS.custom.baseDescription,
-        top: false,
-        isCustom: true,
-        priority: 30, // Low priority by default
-        lowQuality: false,
-        recommended: false
-      }));
-      
-      models = [...models, ...customModelOptions];
+      const customModelOptions = customModels.map(customModel => {
+        const modelMeta = MODELS[customModel.id] || MODELS[customModel.id.replace(/^openrouter\//, '')] || {}; // Match with or without openrouter/
+        return {
+          id: customModel.id, // Use the ID from custom model storage
+          label: customModel.label || formatModelName(customModel.id), // Use label or format ID
+          requiresSubscription: false, // Custom models are assumed free
+          description: modelMeta.description || MODEL_TIERS.custom.baseDescription,
+          top: false,
+          isCustom: true,
+          priority: modelMeta.priority || 30, // Default priority for custom
+          lowQuality: modelMeta.lowQuality || false,
+          recommended: modelMeta.recommended || false,
+          provider: 'custom', // Specific provider key for custom models
+          configured: true, // Custom models are always considered configured
+        };
+      });
+      modelOptionsList.push(...customModelOptions);
     }
-    
-    // Sort models consistently in one place:
-    // 1. First by free/premium (free first)
-    // 2. Then by priority (higher first)
-    // 3. Finally by name (alphabetical)
-    return models.sort((a, b) => {
-      // First by free/premium status
-      if (a.requiresSubscription !== b.requiresSubscription) {
-        return a.requiresSubscription ? 1 : -1;
-      }
-      
-      // Then by priority (higher first)
-      if (a.priority !== b.priority) {
-        return b.priority - a.priority;
-      }
-      
-      // Finally by name
-      return a.label.localeCompare(b.label);
-    });
-  }, [modelsData, isLoadingModels, customModels]);
 
-  // Get filtered list of models the user can access (no additional sorting)
+    // Define provider sort order
+    const providerSortOrder: { [key: string]: number } = {
+      ollama: 1,
+      openai: 2,
+      anthropic: 3,
+      openrouter: 4, // Keep OpenRouter models grouped
+      groq: 5,
+      bedrock: 6,
+      custom: 7, // Custom models last or as per preference
+      default: 8, // Loading state models
+      fallback: 9, // Fallback error state models
+    };
+    
+    // Sort models:
+    // 1. Primary sort: `configured` (true first).
+    // 2. Secondary sort: `provider` (custom order).
+    // 3. Tertiary sort: `priority` (descending).
+    // 4. Quaternary sort: `label` (alphabetical).
+    return modelOptionsList.sort((a, b) => {
+      // Sort by configured (true first)
+      if ((a.configured ?? false) !== (b.configured ?? false)) {
+        return (a.configured ?? false) ? -1 : 1;
+      }
+      // Sort by provider order
+      const aProviderOrder = providerSortOrder[a.provider || 'custom'] || 99;
+      const bProviderOrder = providerSortOrder[b.provider || 'custom'] || 99;
+      if (aProviderOrder !== bProviderOrder) {
+        return aProviderOrder - bProviderOrder;
+      }
+      // Sort by priority (descending)
+      if ((a.priority || 0) !== (b.priority || 0)) {
+        return (b.priority || 0) - (a.priority || 0);
+      }
+      // Sort by label (alphabetical)
+      return (a.label || '').localeCompare(b.label || '');
+    });
+
+  }, [allModelsData, isLoadingAllModels, customModels]);
+
+  // Get filtered list of models the user can access
+  // This will be updated after MODEL_OPTIONS is fully refactored with sorting and custom models.
+  const canAccessModelCheck = (modelId: string, currentSubscriptionStatus: SubscriptionStatus, currentModelOptions: ModelOption[]): boolean => {
+    if (isLocalMode()) return true; // Local mode bypasses normal checks
+    
+    const model = currentModelOptions.find(m => m.id === modelId);
+    if (!model) return false;
+    if (!model.configured) return false; // Provider must be configured
+    
+    // Custom and Ollama models are accessible if their provider is configured (Ollama checked by API, custom is always true)
+    if (model.provider === 'custom' || model.provider === 'ollama') return true; 
+
+    // For other providers, check subscription status vs model's requirement
+    return currentSubscriptionStatus === 'active' || !model.requiresSubscription;
+  };
+  
   const availableModels = useMemo(() => {
-    return isLocalMode() 
-      ? MODEL_OPTIONS 
-      : MODEL_OPTIONS.filter(model => 
-          canAccessModel(subscriptionStatus, model.requiresSubscription)
-        );
+    return MODEL_OPTIONS.filter(model => canAccessModelCheck(model.id, subscriptionStatus, MODEL_OPTIONS));
   }, [MODEL_OPTIONS, subscriptionStatus]);
 
   // Initialize selected model from localStorage or defaults
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    
+    if (typeof window === 'undefined' || MODEL_OPTIONS.length === 0) return;
+
     try {
-      const savedModel = localStorage.getItem(STORAGE_KEY_MODEL);
-      
-      // Local mode - allow any model
-      if (isLocalMode()) {
-        if (savedModel && MODEL_OPTIONS.find(option => option.id === savedModel)) {
-          setSelectedModel(savedModel);
-        } else {
-          setSelectedModel(DEFAULT_PREMIUM_MODEL_ID);
-          saveModelPreference(DEFAULT_PREMIUM_MODEL_ID);
-        }
-        return;
-      }
-      
-      // Premium subscription - ALWAYS use premium model
-      if (subscriptionStatus === 'active') {
-        // If they had a premium model saved and it's still valid, use it
-        const hasSavedPremiumModel = savedModel && 
-          MODEL_OPTIONS.find(option => 
-            option.id === savedModel && 
-            option.requiresSubscription && 
-            canAccessModel(subscriptionStatus, true)
-          );
-        
-        // Otherwise use the default premium model
-        if (hasSavedPremiumModel) {
-          setSelectedModel(savedModel!);
-        } else {
-          setSelectedModel(DEFAULT_PREMIUM_MODEL_ID);
-          saveModelPreference(DEFAULT_PREMIUM_MODEL_ID);
-        }
-        return;
-      }
-      
-      // No subscription - use saved model if accessible (free tier), or default free
-      if (savedModel) {
-        const modelOption = MODEL_OPTIONS.find(option => option.id === savedModel);
-        if (modelOption && canAccessModel(subscriptionStatus, modelOption.requiresSubscription)) {
-          setSelectedModel(savedModel);
-        } else {
-          setSelectedModel(DEFAULT_FREE_MODEL_ID);
-          saveModelPreference(DEFAULT_FREE_MODEL_ID);
-        }
+      const savedModelId = localStorage.getItem(STORAGE_KEY_MODEL);
+      let newSelectedModelId = '';
+
+      // Check if saved model is valid and accessible
+      if (savedModelId && canAccessModelCheck(savedModelId, subscriptionStatus, MODEL_OPTIONS)) {
+        newSelectedModelId = savedModelId;
       } else {
-        setSelectedModel(DEFAULT_FREE_MODEL_ID);
-        saveModelPreference(DEFAULT_FREE_MODEL_ID);
+        // Find a new default model based on priority
+        // 1. Try configured Ollama model
+        let defaultModel = MODEL_OPTIONS.find(m => m.provider === 'ollama' && m.configured);
+        if (defaultModel) {
+          newSelectedModelId = defaultModel.id;
+        } else {
+          // 2. If subscription active, try configured, recommended, premium model
+          if (subscriptionStatus === 'active') {
+            defaultModel = MODEL_OPTIONS.find(m => 
+              m.configured && 
+              m.requiresSubscription && 
+              m.recommended &&
+              m.provider !== 'ollama' // exclude ollama as it was checked
+            );
+            if (defaultModel) newSelectedModelId = defaultModel.id;
+          }
+          
+          // 3. If no model yet, try configured, free, non-Ollama model
+          if (!newSelectedModelId) {
+            defaultModel = MODEL_OPTIONS.find(m => 
+              m.configured && 
+              !m.requiresSubscription && 
+              m.provider !== 'ollama'
+            );
+            if (defaultModel) newSelectedModelId = defaultModel.id;
+          }
+
+          // 4. Fallback to DEFAULT_FREE_MODEL_ID if accessible, then first available
+          if (!newSelectedModelId) {
+            if (canAccessModelCheck(DEFAULT_FREE_MODEL_ID, subscriptionStatus, MODEL_OPTIONS)) {
+              newSelectedModelId = DEFAULT_FREE_MODEL_ID;
+            } else {
+              const firstAvailable = MODEL_OPTIONS.find(m => canAccessModelCheck(m.id, subscriptionStatus, MODEL_OPTIONS));
+              if (firstAvailable) {
+                newSelectedModelId = firstAvailable.id;
+              } else {
+                // This case should ideally not happen if MODEL_OPTIONS has items
+                console.warn("No accessible models found. Defaulting to the first model in the list or empty.");
+                newSelectedModelId = MODEL_OPTIONS.length > 0 ? MODEL_OPTIONS[0].id : ''; 
+              }
+            }
+          }
+        }
       }
+      
+      if (newSelectedModelId) {
+        setSelectedModel(newSelectedModelId);
+        saveModelPreference(newSelectedModelId);
+      } else if (MODEL_OPTIONS.length > 0) {
+        // If after all checks, newSelectedModelId is empty but options are available,
+        // default to the first one (could be a non-configured one if nothing else is available)
+        // This is a safeguard.
+        const fallbackDefault = MODEL_OPTIONS[0].id;
+        setSelectedModel(fallbackDefault);
+        saveModelPreference(fallbackDefault);
+        console.warn(`Default model selection fell back to the first model in the list: ${fallbackDefault}`);
+      } else {
+        // No models available at all (e.g. API error and no defaults loaded)
+        setSelectedModel(''); // Set to empty or a specific "no model available" ID
+        console.warn('No models available to select.');
+      }
+
     } catch (error) {
-      console.warn('Failed to load preferences from localStorage:', error);
-      setSelectedModel(DEFAULT_FREE_MODEL_ID);
+      console.warn('Failed to load model preferences from localStorage or initialize default:', error);
+      // Fallback to a hardcoded default if everything else fails
+      const ultimateFallback = MODEL_OPTIONS.find(m => m.id === DEFAULT_FREE_MODEL_ID && m.configured) 
+                               ? DEFAULT_FREE_MODEL_ID 
+                               : (MODEL_OPTIONS.length > 0 ? MODEL_OPTIONS[0].id : '');
+      setSelectedModel(ultimateFallback);
+      if (ultimateFallback) saveModelPreference(ultimateFallback);
     }
-  }, [subscriptionStatus, MODEL_OPTIONS]);
+  }, [subscriptionStatus, MODEL_OPTIONS, isLoadingAllModels]); // Depend on isLoadingAllModels to re-run when models finish loading
+
 
   // Handle model selection change
   const handleModelChange = (modelId: string) => {
@@ -475,11 +572,12 @@ export const useModelSelection = () => {
     customModels,
     getActualModelId,
     refreshCustomModels,
-    canAccessModel: (modelId: string) => {
-      if (isLocalMode()) return true;
-      const model = MODEL_OPTIONS.find(m => m.id === modelId);
-      return model ? canAccessModel(subscriptionStatus, model.requiresSubscription) : false;
-    },
+    // canAccessModel: (modelId: string) => { // Original canAccessModel replaced by canAccessModelCheck call below
+    //   if (isLocalMode()) return true;
+    //   const model = MODEL_OPTIONS.find(m => m.id === modelId);
+    //   return model ? canAccessModel(subscriptionStatus, model.requiresSubscription) : false;
+    // },
+    canAccessModel: (modelId: string) => canAccessModelCheck(modelId, subscriptionStatus, MODEL_OPTIONS), // Updated to use the new check
     isSubscriptionRequired: (modelId: string) => {
       return MODEL_OPTIONS.find(m => m.id === modelId)?.requiresSubscription || false;
     }

--- a/frontend/src/hooks/react-query/subscriptions/use-model.ts
+++ b/frontend/src/hooks/react-query/subscriptions/use-model.ts
@@ -19,3 +19,15 @@ export const useAvailableModels = createQueryHook<AvailableModelsResponse, Error
       },
     }
   );
+
+import { useQuery } from '@tanstack/react-query';
+import { getAllLlmModels, AllLlmModelsResponse } from '@/lib/api'; // Ensure this path is correct
+
+export const useAllLlmModels = () => {
+  return useQuery<AllLlmModelsResponse, Error>({
+    queryKey: ['allLlmModels'], // queryKeys.allLlmModels() could be added to keys.ts if preferred
+    queryFn: getAllLlmModels,
+    staleTime: 1000 * 60 * 5, // Cache for 5 minutes
+    refetchOnWindowFocus: false, // Optional: prevent refetch on window focus
+  });
+};


### PR DESCRIPTION
This feature enables you to dynamically select and switch between various Large Language Models directly from the application's user interface, without requiring a server restart.

Key changes include:

Backend:
- Added a new API endpoint `/api/llm/all-models` that lists available models. This includes:
  - Dynamically fetched models from a local Ollama server if `OLLAMA_API_BASE` is configured.
  - Predefined lists of popular models for cloud providers (OpenAI, Anthropic, OpenRouter, Groq, Bedrock).
  - Indicates whether each provider is configured on the backend (e.g., API key present).
- Modified model selection logic in agent API (`/agent/start` and `/agent/initiate`) to prioritize model choice from the UI request, falling back to server configuration (`MODEL_TO_USE`) and then a hardcoded default.

Frontend:
- Adapted the `_use-model-selection.ts` hook to fetch model data from the new `/api/llm/all-models` endpoint. It processes this data, merges it with metadata from the local `MODELS` constant, and handles custom models from localStorage.
- Updated the `model-selector.tsx` UI component to:
  - Group models by provider (Ollama, OpenAI, etc.).
  - Clearly display the configuration status of each provider.
  - Disable selection from unconfigured providers.
  - Maintain functionality for paywall logic, custom model management, and search.
- Ensured the selected model ID (including prefixes like `ollama/`) is correctly passed to the backend.

This addresses the issue of allowing you to flexibly change models, including local Ollama instances and various cloud LLMs, via the UI.