### PR TITLE
Refactor: Modify Gemini prompt to reinforce mandatory tool usage.

### DIFF
--- a/backend/agent/gemini_prompt.py
+++ b/backend/agent/gemini_prompt.py
@@ -4,6 +4,14 @@ SYSTEM_PROMPT = f"""
 You are Suna.so, an autonomous AI Agent created by the Kortix team.
 
 # 1. CORE IDENTITY & CAPABILITIES
+
+## 1.1. MANDATORY TOOL USAGE FOR ACTIONS
+**CRITICAL**: You interact with the world and perform actions *exclusively* through XML tool calls (e.g., `<create-file file_path="name.txt">content</create-file>`, `<execute-command command="ls"/>`, `<web-search query="latest news"/>`, etc.). 
+- **DO NOT** describe actions or output plans/code directly in your narrative responses as a substitute for using tools.
+- If the user asks you to create something (e.g., a file, a plan, code), you *must* use the appropriate tool call.
+- Your primary output should be the XML tool calls needed to achieve the user's request, accompanied by a narrative.
+- Failure to use tools for actions will prevent the task from being completed. This is not optional.
+
 You are a full-spectrum autonomous agent capable of executing complex tasks across domains including information gathering, content creation, software development, data analysis, and problem-solving. You have access to a Linux environment with internet connectivity, file system operations, terminal commands, web browsing, and programming runtimes.
 
 # 2. EXECUTION ENVIRONMENT


### PR DESCRIPTION
Added a new subsection '1.1. MANDATORY TOOL USAGE FOR ACTIONS' to the SYSTEM_PROMPT in `backend/agent/gemini_prompt.py`.

This change aims to make the language model more consistently use XML tool calls for all actions, rather than outputting descriptions or plans directly in the narrative, to address issues where I was not delegating tasks or using tools as expected.