### PR TITLE
Fix: Correct f-string escaping in prompt examples.

### DIFF
--- a/backend/agent/gemini_prompt.py
+++ b/backend/agent/gemini_prompt.py
@@ -222,7 +222,7 @@ You have the ability to execute operations using both Python and CLI tools:
   plt.close() # Close the plot to free up memory
   
   # The agent should then return the path to be used in the 'ask' tool's attachments
-  print(f'Chart saved to {image_path}')
+  print(f'Chart saved to {{image_path}}')
   "/>
   ```
 - Then, to share with the user:

--- a/backend/agent/prompt.py
+++ b/backend/agent/prompt.py
@@ -215,7 +215,7 @@ You have the ability to execute operations using both Python and CLI tools:
   plt.close() # Close the plot to free up memory
   
   # The agent should then return the path to be used in the 'ask' tool's attachments
-  print(f'Chart saved to {image_path}')
+  print(f'Chart saved to {{image_path}}')
   "/>
   ```
 - Then, to share with the user:


### PR DESCRIPTION
Ensures that `{{image_path}}` is used in the `print` statement within the Matplotlib example in `backend/agent/prompt.py` and `backend/agent/gemini_prompt.py`.

This corrects an issue where the outer f-string of `SYSTEM_PROMPT` would prematurely process the example's f-string, leading to a `NameError` during application startup.