### PR TITLE
fix: Resolve ModuleNotFoundError in run_agent_background.py

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -1,3 +1,15 @@
+import sys
+import os
+
+# Ensure the '/app' directory (project root inside the container) is in sys.path
+# This allows top-level imports like 'from backend...' , 'from utils...' etc.
+# when the script is run by Dramatiq, which might not inherit Python's default
+# behavior of adding the script's CWD to sys.path for module resolution.
+project_root = '/app' # Standardized in Dockerfile
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# The rest of the script's imports and code will follow.
 import sentry
 import asyncio
 import json


### PR DESCRIPTION
This corrects a `ModuleNotFoundError: No module named 'backend'` that occurred when I was running `run_agent_background.py` and it attempted to import modules using top-level package paths (e.g., `from backend.sandbox...`).

The fix involves adding `/app` (the project root within the Docker container) to `sys.path` at the beginning of `run_agent_background.py`. This ensures that the Python interpreter can correctly locate packages like `backend`, `utils`, `services`, etc., which reside under `/app`.