### PR TITLE
I've adjusted an import path in `run_agent_background.py` to try and …

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -52,7 +52,7 @@ from dramatiq.brokers.rabbitmq import RabbitmqBroker
 import os
 from services.langfuse import langfuse
 # Imports for sandbox stopping
-from backend.sandbox.sandbox import get_or_start_sandbox, daytona
+from sandbox.sandbox import get_or_start_sandbox, daytona
 from daytona_api_client.models.workspace_state import WorkspaceState
 from daytona_sdk import SessionExecuteRequest # Added for workspace cleanup
 


### PR DESCRIPTION
…resolve a `ModuleNotFoundError`.

Specifically, I changed the import from:
`from backend.sandbox.sandbox import ...`
to:
`from sandbox.sandbox import ...`

This change is based on information suggesting the `backend` directory might not be where it was expected, and that the `sandbox` module could be located directly under the application's root directory.

I've kept some diagnostic logging in place, just in case further troubleshooting is needed.