### PR TITLE
feat: Introduce local Docker sandbox execution alternative

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,10 +41,10 @@ TAVILY_API_KEY=
 FIRECRAWL_API_KEY=
 FIRECRAWL_URL=
 
-# Sandbox container provider:
-DAYTONA_API_KEY=
-DAYTONA_SERVER_URL=
-DAYTONA_TARGET=
+# Sandbox container provider (Daytona - Optional, leave blank if using local Docker sandboxes)
+# DAYTONA_API_KEY=
+# DAYTONA_SERVER_URL=https://app.daytona.io/api
+# DAYTONA_TARGET=us
 
 LANGFUSE_PUBLIC_KEY="pk-REDACTED"
 LANGFUSE_SECRET_KEY="sk-REDACTED"

--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -16,7 +16,7 @@ from dramatiq.brokers.rabbitmq import RabbitmqBroker
 import os
 from services.langfuse import langfuse
 # Imports for sandbox stopping
-from sandbox.sandbox import get_or_start_sandbox, daytona # Modified import
+from backend.sandbox.sandbox import get_or_start_sandbox, daytona, use_daytona # Modified import
 from daytona_api_client.models.workspace_state import WorkspaceState
 from daytona_sdk import SessionExecuteRequest # Added for workspace cleanup
 
@@ -292,13 +292,27 @@ async def run_agent_background(
 
                         # 2. Stop the Sandbox
                         logger.info(f"Attempting to stop sandbox: {sandbox_id_for_cleanup_and_stop} after cleanup.")
-                        current_state = sandbox_instance.info().state
-                        logger.info(f"Sandbox {sandbox_id_for_cleanup_and_stop} current state before stop attempt: {current_state}")
-                        if current_state not in [WorkspaceState.STOPPED, WorkspaceState.ARCHIVED, WorkspaceState.STOPPING, WorkspaceState.ARCHIVING]:
-                            await daytona.stop(sandbox_instance)
-                            logger.info(f"Successfully sent stop command to sandbox {sandbox_id_for_cleanup_and_stop}")
+                        if use_daytona():
+                            logger.info(f"Using Daytona to stop sandbox: {sandbox_id_for_cleanup_and_stop}")
+                            current_state = sandbox_instance.info().state
+                            logger.info(f"Daytona sandbox {sandbox_id_for_cleanup_and_stop} current state before stop attempt: {current_state}")
+                            if current_state not in [WorkspaceState.STOPPED, WorkspaceState.ARCHIVED, WorkspaceState.STOPPING, WorkspaceState.ARCHIVING]:
+                                await daytona.stop(sandbox_instance)
+                                logger.info(f"Successfully sent stop command to Daytona sandbox {sandbox_id_for_cleanup_and_stop}")
+                            else:
+                                logger.info(f"Daytona sandbox {sandbox_id_for_cleanup_and_stop} is already in state '{current_state}', no stop action needed.")
                         else:
-                            logger.info(f"Sandbox {sandbox_id_for_cleanup_and_stop} is already in state '{current_state}', no stop action needed.")
+                            logger.info(f"Using local_sandbox to stop sandbox: {sandbox_id_for_cleanup_and_stop}")
+                            # Ensure local_sandbox is imported for this scope
+                            from backend.sandbox.local_sandbox import local_sandbox
+                            current_state = sandbox_instance['info']()['state'] # local_sandbox returns a dict
+                            logger.info(f"Local sandbox {sandbox_id_for_cleanup_and_stop} current state before stop attempt: {current_state}")
+                            # Common Docker states for a stopped container are 'exited' or sometimes 'stopped' (though 'exited' is more canonical for normally stopped)
+                            if current_state not in ['exited', 'stopped', 'stopping']: # 'stopping' could be a transient state
+                                local_sandbox.stop(sandbox_instance) # local_sandbox.stop is synchronous
+                                logger.info(f"Successfully called stop for local sandbox {sandbox_id_for_cleanup_and_stop}")
+                            else:
+                                logger.info(f"Local sandbox {sandbox_id_for_cleanup_and_stop} is already in state '{current_state}', no stop action needed.")
                     else:
                         logger.warning(f"Could not retrieve sandbox instance for ID: {sandbox_id_for_cleanup_and_stop}. Skipping cleanup and stop.")
 

--- a/backend/sandbox/local_sandbox.py
+++ b/backend/sandbox/local_sandbox.py
@@ -1,0 +1,180 @@
+import docker
+import uuid
+import os
+from utils.logger import logger
+from utils.config import config
+
+class LocalSandbox:
+    def __init__(self):
+        self.client = docker.from_env()
+        self.logger = logger
+        
+    def create(self, project_id=None, password=None):
+        """Crear un nuevo sandbox local usando Docker"""
+        sandbox_id = project_id or str(uuid.uuid4())
+        self.logger.info(f"Creando sandbox local con ID: {sandbox_id}")
+        
+        # Configuración del contenedor similar a la de DAYTONA
+        container = self.client.containers.run(
+            image=config.SANDBOX_IMAGE_NAME,
+            detach=True,
+            environment={
+                "CHROME_PERSISTENT_SESSION": "true",
+                "RESOLUTION": "1024x768x24",
+                "RESOLUTION_WIDTH": "1024",
+                "RESOLUTION_HEIGHT": "768",
+                "VNC_PASSWORD": password or "suna",
+                "ANONYMIZED_TELEMETRY": "false",
+                "CHROME_DEBUGGING_PORT": "9222",
+                "CHROME_DEBUGGING_HOST": "localhost",
+            },
+            ports={
+                '5900/tcp': None,  # VNC
+                '9222/tcp': None,  # Chrome debugging
+            },
+            name=f"suna-sandbox-{sandbox_id}",
+            labels={
+                'id': sandbox_id,
+                'type': 'suna-sandbox'
+            }
+        )
+        
+        # Configurar el entorno de visualización
+        self._setup_visualization_environment(container)
+        
+        # Iniciar supervisord
+        self._start_supervisord(container)
+        
+        return {
+            'id': sandbox_id,
+            'container': container,
+            'info': lambda: self._get_container_info(container),
+            'process': {
+                'create_session': lambda session_id: None,
+                'execute_session_command': lambda session_id, command: self._execute_command(container, command),
+                'delete_session': lambda session_id: None,
+                'get_session_command_logs': lambda session_id, cmd_id: ""
+            }
+        }
+    
+    def get_current_sandbox(self, sandbox_id):
+        """Obtener un sandbox existente por ID"""
+        try:
+            container = self.client.containers.get(f"suna-sandbox-{sandbox_id}")
+            return {
+                'id': sandbox_id,
+                'container': container,
+                'instance': {
+                    'state': container.status
+                },
+                'info': lambda: self._get_container_info(container),
+                'process': {
+                    'create_session': lambda session_id: None,
+                    'execute_session_command': lambda session_id, command: self._execute_command(container, command),
+                    'delete_session': lambda session_id: None,
+                    'get_session_command_logs': lambda session_id, cmd_id: ""
+                }
+            }
+        except Exception as e:
+            self.logger.error(f"Error al obtener sandbox local: {str(e)}")
+            raise e
+    
+    def start(self, sandbox):
+        """Iniciar un sandbox detenido"""
+        try:
+            container = sandbox['container']
+            container.start()
+            self.logger.info(f"Sandbox local {sandbox['id']} iniciado")
+            
+            # Iniciar supervisord
+            self._start_supervisord(container)
+            
+            return sandbox
+        except Exception as e:
+            self.logger.error(f"Error al iniciar sandbox local: {str(e)}")
+            raise e
+    
+    def stop(self, sandbox):
+        """Detener un sandbox en ejecución"""
+        try:
+            container = sandbox['container']
+            container.stop()
+            self.logger.info(f"Sandbox local {sandbox['id']} detenido")
+        except Exception as e:
+            self.logger.error(f"Error al detener sandbox local: {str(e)}")
+            raise e
+    
+    def _execute_command(self, container, command_request):
+        """Ejecutar un comando en el contenedor"""
+        try:
+            cmd = command_request.command if hasattr(command_request, 'command') else command_request
+            cwd = command_request.cwd if hasattr(command_request, 'cwd') else "/workspace"
+            
+            # Ejecutar el comando
+            exit_code, output = container.exec_run(
+                cmd=f"cd {cwd} && {cmd}",
+                stdout=True,
+                stderr=True
+            )
+            
+            return {
+                'cmd_id': str(uuid.uuid4()),
+                'exit_code': exit_code,
+                'output': output.decode('utf-8', errors='replace')
+            }
+        except Exception as e:
+            self.logger.error(f"Error al ejecutar comando en sandbox local: {str(e)}")
+            raise e
+    
+    def _setup_visualization_environment(self, container):
+        """Configurar el entorno de visualización en el sandbox"""
+        try:
+            self.logger.info("Configurando entorno de visualización para sandbox local")
+            
+            # Instalar paquetes necesarios
+            exit_code, output = container.exec_run(
+                cmd="pip install matplotlib pandas seaborn plotly",
+                stdout=True,
+                stderr=True
+            )
+            
+            if exit_code == 0:
+                self.logger.info("Paquetes de visualización instalados correctamente")
+            else:
+                self.logger.error(f"Error al instalar paquetes de visualización: {output.decode('utf-8')}")
+            
+            # Crear directorio de visualizaciones
+            container.exec_run(cmd="mkdir -p /workspace/visualizations")
+            
+        except Exception as e:
+            self.logger.error(f"Error al configurar entorno de visualización: {str(e)}")
+    
+    def _start_supervisord(self, container):
+        """Iniciar supervisord en el contenedor"""
+        try:
+            self.logger.info("Iniciando supervisord en sandbox local")
+            
+            exit_code, output = container.exec_run(
+                cmd="/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf",
+                detach=True
+            )
+            
+            # Note: For detached exec_run, exit_code might not be immediately useful
+            # or might indicate the command was launched, not its completion status.
+            # Consider logging output if available, but be aware it might be empty for detached processes.
+            self.logger.info(f"Supervisord launch attempted. Exit code: {exit_code}. Output: {output.decode('utf-8') if output else 'N/A'}")
+            # A more robust check might involve checking container logs or process status if critical
+
+        except Exception as e:
+            self.logger.error(f"Error al iniciar supervisord: {str(e)}")
+    
+    def _get_container_info(self, container):
+        """Obtener información del contenedor"""
+        container.reload()
+        return {
+            'state': container.status,
+            'ports': container.ports
+        }
+
+# Instancia global
+local_sandbox = LocalSandbox()

--- a/backend/tests/sandbox/test_local_sandbox.py
+++ b/backend/tests/sandbox/test_local_sandbox.py
@@ -1,0 +1,308 @@
+import unittest
+from unittest.mock import patch, MagicMock, call, ANY
+import uuid # For checking command IDs or sandbox IDs if needed
+
+# Attempt to import docker errors for more specific exception testing
+try:
+    from docker import errors as docker_errors
+except ImportError:
+    # If docker is not installed in the test environment, create a dummy class for the test
+    class DockerErrors:
+        class NotFound(Exception):
+            pass
+    docker_errors = DockerErrors()
+
+# Assuming utils.logger and utils.config are importable or can be mocked.
+# For the purpose of these tests, we will mock them where they are imported 
+# in local_sandbox.py. The LocalSandbox class itself receives logger and config
+# through its imports, so we patch at 'backend.sandbox.local_sandbox.logger' etc.
+
+# The class to test
+from backend.sandbox.local_sandbox import LocalSandbox
+
+class TestLocalSandbox(unittest.TestCase):
+
+    @patch('backend.sandbox.local_sandbox.config')
+    @patch('backend.sandbox.local_sandbox.logger')
+    @patch('backend.sandbox.local_sandbox.docker')
+    def setUp(self, mock_docker_module, mock_logger_module, mock_config_module):
+        # Mock the Docker client returned by docker.from_env()
+        self.mock_docker_client = MagicMock()
+        mock_docker_module.from_env.return_value = self.mock_docker_client
+        
+        # Set up default mock config values (as accessed by LocalSandbox)
+        # The LocalSandbox class imports 'config' directly, so we patch 'backend.sandbox.local_sandbox.config'
+        mock_config_module.SANDBOX_IMAGE_NAME = "test/image:latest"
+        
+        # Instantiate the LocalSandbox
+        self.sandbox_manager = LocalSandbox()
+        
+        # Replace the instance's logger with the mock_logger_module if desired,
+        # or trust the patcher to handle it if LocalSandbox uses 'logger.info' etc.
+        # For direct assertion on the logger instance used by sandbox_manager:
+        self.sandbox_manager.logger = mock_logger_module
+        self.mock_logger = mock_logger_module # Keep a reference for assertions
+
+    def test_init(self):
+        """Test that docker.from_env() is called upon instantiation."""
+        # setUp already creates an instance, so we just need to assert
+        # that docker.from_env was called during its __init__.
+        # The patch for docker is on 'backend.sandbox.local_sandbox.docker'
+        # So, we access its from_env attribute.
+        # We need to ensure the patch is active when LocalSandbox is instantiated.
+        # This is implicitly handled by setUp running before each test.
+        
+        # To explicitly test __init__ behavior if it were more complex:
+        with patch('backend.sandbox.local_sandbox.docker') as new_mock_docker:
+            new_client = MagicMock()
+            new_mock_docker.from_env.return_value = new_client
+            LocalSandbox()
+            new_mock_docker.from_env.assert_called_once()
+
+    @patch('backend.sandbox.local_sandbox.uuid.uuid4')
+    def test_create_sandbox_default_id_and_password(self, mock_uuid_module):
+        mock_uuid_module.return_value = "test-uuid"
+        
+        mock_container_instance = MagicMock()
+        mock_container_instance.name = "suna-sandbox-test-uuid"
+        # Simulate return values for exec_run for various setup steps
+        # (pip install, mkdir, supervisord)
+        mock_container_instance.exec_run.side_effect = [
+            (0, b"pip install successful"), # For _setup_visualization_environment
+            (0, b"mkdir successful"),       # For _setup_visualization_environment
+            (0, b"supervisord started")     # For _start_supervisord
+        ]
+        self.mock_docker_client.containers.run.return_value = mock_container_instance
+
+        sandbox = self.sandbox_manager.create()
+
+        self.mock_docker_client.containers.run.assert_called_once_with(
+            image="test/image:latest", # From mock_config_module.SANDBOX_IMAGE_NAME
+            detach=True,
+            environment={
+                "CHROME_PERSISTENT_SESSION": "true",
+                "RESOLUTION": "1024x768x24",
+                "RESOLUTION_WIDTH": "1024",
+                "RESOLUTION_HEIGHT": "768",
+                "VNC_PASSWORD": "suna", # Default password
+                "ANONYMIZED_TELEMETRY": "false",
+                "CHROME_DEBUGGING_PORT": "9222",
+                "CHROME_DEBUGGING_HOST": "localhost",
+            },
+            ports={'5900/tcp': None, '9222/tcp': None},
+            name="suna-sandbox-test-uuid",
+            labels={'id': 'test-uuid', 'type': 'suna-sandbox'}
+        )
+        self.assertEqual(sandbox['id'], 'test-uuid')
+        self.assertEqual(sandbox['container'], mock_container_instance)
+        
+        # Verify calls for setup methods
+        calls = [
+            call(cmd="pip install matplotlib pandas seaborn plotly", stdout=True, stderr=True),
+            call(cmd="mkdir -p /workspace/visualizations"),
+            call(cmd="/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf", detach=True)
+        ]
+        mock_container_instance.exec_run.assert_has_calls(calls, any_order=False) # Order matters here
+
+        # Test the info lambda
+        mock_container_instance.reload.return_value = None # Mock reload
+        mock_container_instance.status = "running"
+        mock_container_instance.ports = {'5900/tcp': [{'HostIp': '0.0.0.0', 'HostPort': '32768'}]}
+        info_result = sandbox['info']()
+        self.assertEqual(info_result['state'], "running")
+        self.assertEqual(info_result['ports'], {'5900/tcp': [{'HostIp': '0.0.0.0', 'HostPort': '32768'}]})
+        mock_container_instance.reload.assert_called_once()
+
+        # Test the process lambda (execute_session_command)
+        mock_container_instance.exec_run.reset_mock() # Reset from setup calls
+        mock_exec_output = (0, b"command output")
+        mock_container_instance.exec_run.return_value = mock_exec_output
+        
+        with patch('backend.sandbox.local_sandbox.uuid.uuid4') as mock_cmd_uuid:
+            mock_cmd_uuid.return_value = "cmd-uuid"
+            exec_result = sandbox['process']['execute_session_command']("session1", "echo hello")
+            self.assertEqual(exec_result['cmd_id'], "cmd-uuid")
+            self.assertEqual(exec_result['exit_code'], 0)
+            self.assertEqual(exec_result['output'], "command output")
+            mock_container_instance.exec_run.assert_called_once_with(
+                cmd="cd /workspace && echo hello", stdout=True, stderr=True
+            )
+
+    @patch('backend.sandbox.local_sandbox.uuid.uuid4')
+    def test_create_sandbox_with_project_id_and_password(self, mock_uuid_module):
+        # This ensures that uuid.uuid4 is not called if project_id is provided
+        # mock_uuid_module should not be called.
+        
+        mock_container_instance = MagicMock()
+        mock_container_instance.name = "suna-sandbox-custom-project"
+        mock_container_instance.exec_run.side_effect = [(0, b""), (0, b""), (0, b"")]
+        self.mock_docker_client.containers.run.return_value = mock_container_instance
+
+        sandbox = self.sandbox_manager.create(project_id="custom-project", password="custom_password")
+
+        mock_uuid_module.assert_not_called()
+        self.mock_docker_client.containers.run.assert_called_once_with(
+            image=ANY, detach=ANY, environment=ANY, ports=ANY, # Check specific if needed
+            name="suna-sandbox-custom-project",
+            labels={'id': 'custom-project', 'type': 'suna-sandbox'}
+        )
+        # Check if custom_password was used in environment
+        args, kwargs = self.mock_docker_client.containers.run.call_args
+        self.assertEqual(kwargs['environment']['VNC_PASSWORD'], 'custom_password')
+        self.assertEqual(sandbox['id'], 'custom-project')
+
+
+    def test_get_current_sandbox_success(self):
+        mock_container_instance = MagicMock()
+        mock_container_instance.status = "running"
+        self.mock_docker_client.containers.get.return_value = mock_container_instance
+
+        sandbox = self.sandbox_manager.get_current_sandbox("existing-id")
+
+        self.mock_docker_client.containers.get.assert_called_once_with("suna-sandbox-existing-id")
+        self.assertEqual(sandbox['id'], "existing-id")
+        self.assertEqual(sandbox['container'], mock_container_instance)
+        self.assertEqual(sandbox['instance']['state'], "running")
+
+    def test_get_current_sandbox_not_found(self):
+        self.mock_docker_client.containers.get.side_effect = docker_errors.NotFound("Container not found")
+        
+        with self.assertRaises(docker_errors.NotFound):
+            self.sandbox_manager.get_current_sandbox("non-existent-id")
+        
+        self.mock_docker_client.containers.get.assert_called_once_with("suna-sandbox-non-existent-id")
+        self.mock_logger.error.assert_called_once() # Check that an error was logged
+
+    def test_start_sandbox(self):
+        mock_container_instance = MagicMock()
+        # Mock for _start_supervisord call
+        mock_container_instance.exec_run.return_value = (0, b"supervisord output")
+
+        sandbox_dict = {
+            'id': 'test-id',
+            'container': mock_container_instance
+        }
+        
+        returned_sandbox = self.sandbox_manager.start(sandbox_dict)
+
+        mock_container_instance.start.assert_called_once()
+        # Check _start_supervisord call
+        mock_container_instance.exec_run.assert_called_once_with(
+            cmd="/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf", 
+            detach=True
+        )
+        self.assertEqual(returned_sandbox, sandbox_dict)
+        self.mock_logger.info.assert_any_call("Sandbox local test-id iniciado")
+
+
+    def test_stop_sandbox(self):
+        mock_container_instance = MagicMock()
+        sandbox_dict = {
+            'id': 'test-id',
+            'container': mock_container_instance
+        }
+        self.sandbox_manager.stop(sandbox_dict)
+        mock_container_instance.stop.assert_called_once()
+        self.mock_logger.info.assert_called_once_with("Sandbox local test-id detenido")
+
+    @patch('backend.sandbox.local_sandbox.uuid.uuid4')
+    def test_execute_command_as_string(self, mock_cmd_uuid):
+        mock_cmd_uuid.return_value = "cmd-test-uuid"
+        mock_container_instance = MagicMock()
+        mock_container_instance.exec_run.return_value = (0, b"output string")
+
+        command_request = "ls -l"
+        result = self.sandbox_manager._execute_command(mock_container_instance, command_request)
+
+        mock_container_instance.exec_run.assert_called_once_with(
+            cmd=f"cd /workspace && {command_request}", # Default cwd
+            stdout=True, stderr=True
+        )
+        self.assertEqual(result['cmd_id'], "cmd-test-uuid")
+        self.assertEqual(result['exit_code'], 0)
+        self.assertEqual(result['output'], "output string")
+
+    @patch('backend.sandbox.local_sandbox.uuid.uuid4')
+    def test_execute_command_as_object(self, mock_cmd_uuid):
+        mock_cmd_uuid.return_value = "cmd-obj-uuid"
+        mock_container_instance = MagicMock()
+        mock_container_instance.exec_run.return_value = (1, b"error output")
+
+        command_request_obj = MagicMock()
+        command_request_obj.command = "python script.py"
+        command_request_obj.cwd = "/app"
+        
+        result = self.sandbox_manager._execute_command(mock_container_instance, command_request_obj)
+
+        mock_container_instance.exec_run.assert_called_once_with(
+            cmd=f"cd /app && python script.py",
+            stdout=True, stderr=True
+        )
+        self.assertEqual(result['cmd_id'], "cmd-obj-uuid")
+        self.assertEqual(result['exit_code'], 1)
+        self.assertEqual(result['output'], "error output")
+
+    def test_setup_visualization_environment_success(self):
+        mock_container_instance = MagicMock()
+        # Simulate successful pip install and mkdir
+        mock_container_instance.exec_run.side_effect = [
+            (0, b"pip install successful"), 
+            (0, b"mkdir successful")
+        ]
+
+        self.sandbox_manager._setup_visualization_environment(mock_container_instance)
+
+        calls = [
+            call(cmd="pip install matplotlib pandas seaborn plotly", stdout=True, stderr=True),
+            call(cmd="mkdir -p /workspace/visualizations")
+        ]
+        mock_container_instance.exec_run.assert_has_calls(calls, any_order=False)
+        self.mock_logger.info.assert_any_call("Paquetes de visualización instalados correctamente")
+
+    def test_setup_visualization_environment_pip_fail(self):
+        mock_container_instance = MagicMock()
+        # Simulate failed pip install
+        mock_container_instance.exec_run.side_effect = [
+            (1, b"pip install failed error message"), 
+            # mkdir might still be called or not depending on error handling, let's assume it is
+            (0, b"mkdir successful") 
+        ]
+
+        self.sandbox_manager._setup_visualization_environment(mock_container_instance)
+        
+        mock_container_instance.exec_run.assert_any_call(cmd="pip install matplotlib pandas seaborn plotly", stdout=True, stderr=True)
+        self.mock_logger.error.assert_any_call("Error al instalar paquetes de visualización: pip install failed error message")
+        # Check if mkdir was still called (good to know the behavior)
+        mock_container_instance.exec_run.assert_any_call(cmd="mkdir -p /workspace/visualizations")
+
+
+    def test_start_supervisord(self):
+        mock_container_instance = MagicMock()
+        mock_container_instance.exec_run.return_value = (0, b"supervisord output") # Though detached, mock a typical successful launch tuple
+
+        self.sandbox_manager._start_supervisord(mock_container_instance)
+
+        mock_container_instance.exec_run.assert_called_once_with(
+            cmd="/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf",
+            detach=True
+        )
+        self.mock_logger.info.assert_any_call("Iniciando supervisord en sandbox local")
+        self.mock_logger.info.assert_any_call(f"Supervisord launch attempted. Exit code: 0. Output: supervisord output")
+
+
+    def test_get_container_info(self):
+        mock_container_instance = MagicMock()
+        mock_container_instance.status = "paused"
+        mock_container_instance.ports = {'1234/tcp': None}
+        
+        # reload() is called on the container, doesn't return anything itself
+        mock_container_instance.reload.return_value = None 
+
+        info = self.sandbox_manager._get_container_info(mock_container_instance)
+
+        mock_container_instance.reload.assert_called_once()
+        self.assertEqual(info['state'], "paused")
+        self.assertEqual(info['ports'], {'1234/tcp': None})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/tests/sandbox/test_sandbox_logic.py
+++ b/backend/tests/sandbox/test_sandbox_logic.py
@@ -1,0 +1,224 @@
+import unittest
+from unittest.mock import patch, MagicMock, ANY, call, AsyncMock
+import asyncio
+
+# Import the items to be tested
+from backend.sandbox.sandbox import use_daytona, get_or_start_sandbox, create_sandbox
+
+# Attempt to import WorkspaceState for Daytona tests
+try:
+    from daytona_api_client.models.workspace_state import WorkspaceState
+except ImportError:
+    # Create a dummy WorkspaceState if daytona_api_client is not available in test env
+    class DummyWorkspaceState:
+        STOPPED = "STOPPED"
+        ARCHIVED = "ARCHIVED"
+        RUNNING = "RUNNING" # Add other states if needed by tests
+    WorkspaceState = DummyWorkspaceState()
+
+
+class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
+
+    # --- Tests for use_daytona ---
+    @patch('backend.sandbox.sandbox.config')
+    def test_use_daytona_true_when_all_set(self, mock_config):
+        mock_config.DAYTONA_API_KEY = "test_key"
+        mock_config.DAYTONA_SERVER_URL = "http://test.server"
+        mock_config.DAYTONA_TARGET = "test_target"
+        self.assertTrue(use_daytona())
+
+    @patch('backend.sandbox.sandbox.config')
+    def test_use_daytona_false_if_api_key_missing(self, mock_config):
+        mock_config.DAYTONA_API_KEY = None
+        mock_config.DAYTONA_SERVER_URL = "http://test.server"
+        mock_config.DAYTONA_TARGET = "test_target"
+        self.assertFalse(use_daytona())
+
+    @patch('backend.sandbox.sandbox.config')
+    def test_use_daytona_false_if_server_url_missing(self, mock_config):
+        mock_config.DAYTONA_API_KEY = "test_key"
+        mock_config.DAYTONA_SERVER_URL = "" # Empty string
+        mock_config.DAYTONA_TARGET = "test_target"
+        self.assertFalse(use_daytona())
+
+    @patch('backend.sandbox.sandbox.config')
+    def test_use_daytona_false_if_target_missing(self, mock_config):
+        mock_config.DAYTONA_API_KEY = "test_key"
+        mock_config.DAYTONA_SERVER_URL = "http://test.server"
+        mock_config.DAYTONA_TARGET = None
+        self.assertFalse(use_daytona())
+
+    # --- Tests for get_or_start_sandbox ---
+
+    @patch('backend.sandbox.sandbox.start_supervisord_session') # Mock helper
+    @patch('backend.sandbox.sandbox.logger')
+    @patch('backend.sandbox.sandbox.daytona') # Mock daytona client instance
+    @patch('backend.sandbox.sandbox.use_daytona') # Mock the function itself
+    async def test_get_or_start_sandbox_daytona_running(self, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord):
+        mock_use_daytona_func.return_value = True
+        
+        mock_daytona_sandbox_instance = MagicMock()
+        mock_daytona_sandbox_instance.instance.state = WorkspaceState.RUNNING
+        mock_daytona_client.get_current_sandbox.return_value = mock_daytona_sandbox_instance
+
+        sandbox_id = "daytona-test-id"
+        result = await get_or_start_sandbox(sandbox_id)
+
+        mock_daytona_client.get_current_sandbox.assert_called_once_with(sandbox_id)
+        mock_daytona_client.start.assert_not_called()
+        mock_start_supervisord.assert_not_called()
+        self.assertEqual(result, mock_daytona_sandbox_instance)
+        mock_logger.info.assert_any_call(f"Getting or starting sandbox with ID: {sandbox_id}")
+        mock_logger.info.assert_any_call("Using Daytona for sandbox operations")
+
+    @patch('backend.sandbox.sandbox.start_supervisord_session')
+    @patch('backend.sandbox.sandbox.logger')
+    @patch('backend.sandbox.sandbox.daytona')
+    @patch('backend.sandbox.sandbox.use_daytona')
+    async def test_get_or_start_sandbox_daytona_stopped_starts_it(self, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord):
+        mock_use_daytona_func.return_value = True
+        
+        initial_mock_sandbox = MagicMock()
+        initial_mock_sandbox.instance.state = WorkspaceState.STOPPED
+        
+        started_mock_sandbox = MagicMock() # Simulate state refresh after start
+        started_mock_sandbox.instance.state = WorkspaceState.RUNNING
+
+        # get_current_sandbox will be called twice: once initially, once after start
+        mock_daytona_client.get_current_sandbox.side_effect = [initial_mock_sandbox, started_mock_sandbox]
+        mock_daytona_client.start = AsyncMock() # daytona.start is likely async if get_or_start is
+
+        sandbox_id = "daytona-stopped-id"
+        result = await get_or_start_sandbox(sandbox_id)
+
+        mock_daytona_client.get_current_sandbox.assert_has_calls([call(sandbox_id), call(sandbox_id)])
+        mock_daytona_client.start.assert_called_once_with(initial_mock_sandbox)
+        mock_start_supervisord.assert_called_once_with(started_mock_sandbox)
+        self.assertEqual(result, started_mock_sandbox)
+
+    @patch('backend.sandbox.sandbox.logger')
+    @patch('backend.sandbox.sandbox.local_sandbox') # Mock local_sandbox object
+    @patch('backend.sandbox.sandbox.use_daytona')
+    async def test_get_or_start_sandbox_local_exists_running(self, mock_use_daytona_func, mock_ls_object, mock_logger):
+        mock_use_daytona_func.return_value = False # Use local sandbox
+        
+        mock_local_sandbox_instance = {
+            'id': 'local-id-running',
+            'container': MagicMock(),
+            'instance': {'state': 'running'}, # local_sandbox uses dicts
+            'info': MagicMock(return_value={'state': 'running'})
+        }
+        mock_ls_object.get_current_sandbox.return_value = mock_local_sandbox_instance
+
+        sandbox_id = "local-id-running"
+        result = await get_or_start_sandbox(sandbox_id)
+
+        mock_ls_object.get_current_sandbox.assert_called_once_with(sandbox_id)
+        mock_ls_object.start.assert_not_called()
+        self.assertEqual(result, mock_local_sandbox_instance)
+        mock_logger.info.assert_any_call("Using local sandbox for operations")
+
+    @patch('backend.sandbox.sandbox.logger')
+    @patch('backend.sandbox.sandbox.local_sandbox')
+    @patch('backend.sandbox.sandbox.use_daytona')
+    async def test_get_or_start_sandbox_local_exists_exited_starts_it(self, mock_use_daytona_func, mock_ls_object, mock_logger):
+        mock_use_daytona_func.return_value = False
+        
+        initial_local_sandbox = {
+            'id': 'local-id-exited',
+            'container': MagicMock(),
+            'instance': {'state': 'exited'},
+            'info': MagicMock(return_value={'state': 'exited'})
+        }
+        started_local_sandbox = {**initial_local_sandbox, 'instance': {'state': 'running'}}
+
+        mock_ls_object.get_current_sandbox.return_value = initial_local_sandbox
+        mock_ls_object.start.return_value = started_local_sandbox # start returns the started sandbox
+
+        sandbox_id = "local-id-exited"
+        result = await get_or_start_sandbox(sandbox_id)
+
+        mock_ls_object.get_current_sandbox.assert_called_once_with(sandbox_id)
+        mock_ls_object.start.assert_called_once_with(initial_local_sandbox)
+        self.assertEqual(result, started_local_sandbox)
+
+    @patch('backend.sandbox.sandbox.logger')
+    @patch('backend.sandbox.sandbox.local_sandbox')
+    @patch('backend.sandbox.sandbox.use_daytona')
+    async def test_get_or_start_sandbox_local_not_found_creates_new(self, mock_use_daytona_func, mock_ls_object, mock_logger):
+        mock_use_daytona_func.return_value = False
+        # Simulate local_sandbox.get_current_sandbox raising an error (e.g., docker.errors.NotFound)
+        mock_ls_object.get_current_sandbox.side_effect = Exception("Simulated Docker Not Found")
+        
+        created_local_sandbox = {
+            'id': 'new-local-id',
+            'container': MagicMock(),
+            'instance': {'state': 'running'},
+            'info': MagicMock(return_value={'state': 'running'})
+        }
+        mock_ls_object.create.return_value = created_local_sandbox
+
+        sandbox_id = "new-local-id"
+        result = await get_or_start_sandbox(sandbox_id)
+
+        mock_ls_object.get_current_sandbox.assert_called_once_with(sandbox_id)
+        mock_ls_object.create.assert_called_once_with(project_id=sandbox_id)
+        self.assertEqual(result, created_local_sandbox)
+
+    # --- Tests for create_sandbox ---
+
+    @patch('backend.sandbox.sandbox.setup_visualization_environment')
+    @patch('backend.sandbox.sandbox.start_supervisord_session')
+    @patch('backend.sandbox.sandbox.logger')
+    @patch('backend.sandbox.sandbox.daytona')
+    @patch('backend.sandbox.sandbox.use_daytona')
+    @patch('backend.sandbox.sandbox.Configuration') # For Configuration.SANDBOX_IMAGE_NAME
+    async def test_create_sandbox_daytona_path(self, mock_configuration, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord, mock_setup_viz):
+        mock_use_daytona_func.return_value = True
+        mock_configuration.SANDBOX_IMAGE_NAME = "daytona/image:latest"
+        
+        mock_created_daytona_sandbox = MagicMock()
+        mock_daytona_client.create.return_value = mock_created_daytona_sandbox
+
+        project_id = "daytona-proj-id"
+        password = "secure_password"
+        
+        result = create_sandbox(password=password, project_id=project_id) # create_sandbox is sync
+
+        mock_daytona_client.create.assert_called_once_with(ANY) # ANY for CreateSandboxParams
+        args, kwargs = mock_daytona_client.create.call_args
+        created_params = args[0] # CreateSandboxParams is the first arg
+        
+        self.assertEqual(created_params.image, "daytona/image:latest")
+        self.assertEqual(created_params.labels, {'id': project_id})
+        self.assertEqual(created_params.name, f"suna-sandbox-{project_id}")
+        self.assertEqual(created_params.env_vars["VNC_PASSWORD"], password)
+
+        mock_setup_viz.assert_called_once_with(mock_created_daytona_sandbox)
+        mock_start_supervisord.assert_called_once_with(mock_created_daytona_sandbox)
+        self.assertEqual(result, mock_created_daytona_sandbox)
+
+    @patch('backend.sandbox.sandbox.logger')
+    @patch('backend.sandbox.sandbox.local_sandbox')
+    @patch('backend.sandbox.sandbox.use_daytona')
+    async def test_create_sandbox_local_path(self, mock_use_daytona_func, mock_ls_object, mock_logger):
+        mock_use_daytona_func.return_value = False
+
+        mock_created_local_sandbox = {
+            'id': 'local-proj-id',
+            'container': MagicMock(),
+            'info': MagicMock(return_value={'state': 'running'})
+        }
+        mock_ls_object.create.return_value = mock_created_local_sandbox
+        
+        project_id = "local-proj-id"
+        password = "local_password"
+
+        result = create_sandbox(password=password, project_id=project_id) # create_sandbox is sync
+
+        mock_ls_object.create.assert_called_once_with(project_id=project_id, password=password)
+        self.assertEqual(result, mock_created_local_sandbox)
+        mock_logger.info.assert_any_call(f"Creating new local sandbox with project_id: {project_id}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces an alternative for my execution by enabling me to run in local Docker containers.

Key changes:
- Added `backend/sandbox/local_sandbox.py` with the `LocalSandbox` class to manage local Docker containers (create, start, stop, exec).
- Modified `backend/sandbox/sandbox.py` to conditionally use `LocalSandbox` or another execution environment based on environment variable configuration (`DAYTONA_API_KEY`, etc.). A `use_daytona()` function was added for this.
- Updated `backend/run_agent_background.py` to correctly stop either the other execution environment or local sandboxes.
- Modified `backend/.env.example` to mark certain environment variables as optional.
- Enhanced `setup.py` to:
    - Allow you to choose between different execution modes.
    - Conditionally configure environment variables for one of the execution modes.
    - Install the `docker` Python package if local mode is selected.
- Added unit tests for `LocalSandbox` in `backend/tests/sandbox/test_local_sandbox.py`.
- Added unit tests for the modified logic in `sandbox.py` in `backend/tests/sandbox/test_sandbox_logic.py`.

This change allows you to run the Suna environment entirely on your local machine without relying on an external cloud service, reducing costs and simplifying local development and testing.