### PR TITLE
fix: Use relative import for local_sandbox in sandbox.py

### DIFF
--- a/backend/sandbox/local_sandbox.py
+++ b/backend/sandbox/local_sandbox.py
@@ -8,12 +8,12 @@ class LocalSandbox:
     def __init__(self):
         self.client = docker.from_env()
         self.logger = logger
-        
+
     def create(self, project_id=None, password=None):
         """Crear un nuevo sandbox local usando Docker"""
         sandbox_id = project_id or str(uuid.uuid4())
         self.logger.info(f"Creando sandbox local con ID: {sandbox_id}")
-        
+
         # Configuración del contenedor similar a la de DAYTONA
         container = self.client.containers.run(
             image=config.SANDBOX_IMAGE_NAME,
@@ -38,13 +38,13 @@ class LocalSandbox:
                 'type': 'suna-sandbox'
             }
         )
-        
+
         # Configurar el entorno de visualización
         self._setup_visualization_environment(container)
-        
+
         # Iniciar supervisord
         self._start_supervisord(container)
-        
+
         return {
             'id': sandbox_id,
             'container': container,
@@ -56,7 +56,7 @@ class LocalSandbox:
                 'get_session_command_logs': lambda session_id, cmd_id: ""
             }
         }
-    
+
     def get_current_sandbox(self, sandbox_id):
         """Obtener un sandbox existente por ID"""
         try:
@@ -78,22 +78,22 @@ class LocalSandbox:
         except Exception as e:
             self.logger.error(f"Error al obtener sandbox local: {str(e)}")
             raise e
-    
+
     def start(self, sandbox):
         """Iniciar un sandbox detenido"""
         try:
             container = sandbox['container']
             container.start()
             self.logger.info(f"Sandbox local {sandbox['id']} iniciado")
-            
+
             # Iniciar supervisord
             self._start_supervisord(container)
-            
+
             return sandbox
         except Exception as e:
             self.logger.error(f"Error al iniciar sandbox local: {str(e)}")
             raise e
-    
+
     def stop(self, sandbox):
         """Detener un sandbox en ejecución"""
         try:
@@ -103,20 +103,20 @@ class LocalSandbox:
         except Exception as e:
             self.logger.error(f"Error al detener sandbox local: {str(e)}")
             raise e
-    
+
     def _execute_command(self, container, command_request):
         """Ejecutar un comando en el contenedor"""
         try:
             cmd = command_request.command if hasattr(command_request, 'command') else command_request
             cwd = command_request.cwd if hasattr(command_request, 'cwd') else "/workspace"
-            
+
             # Ejecutar el comando
             exit_code, output = container.exec_run(
                 cmd=f"cd {cwd} && {cmd}",
                 stdout=True,
                 stderr=True
             )
-            
+
             return {
                 'cmd_id': str(uuid.uuid4()),
                 'exit_code': exit_code,
@@ -125,40 +125,40 @@ class LocalSandbox:
         except Exception as e:
             self.logger.error(f"Error al ejecutar comando en sandbox local: {str(e)}")
             raise e
-    
+
     def _setup_visualization_environment(self, container):
         """Configurar el entorno de visualización en el sandbox"""
         try:
             self.logger.info("Configurando entorno de visualización para sandbox local")
-            
+
             # Instalar paquetes necesarios
             exit_code, output = container.exec_run(
                 cmd="pip install matplotlib pandas seaborn plotly",
                 stdout=True,
                 stderr=True
             )
-            
+
             if exit_code == 0:
                 self.logger.info("Paquetes de visualización instalados correctamente")
             else:
                 self.logger.error(f"Error al instalar paquetes de visualización: {output.decode('utf-8')}")
-            
+
             # Crear directorio de visualizaciones
             container.exec_run(cmd="mkdir -p /workspace/visualizations")
-            
+
         except Exception as e:
             self.logger.error(f"Error al configurar entorno de visualización: {str(e)}")
-    
+
     def _start_supervisord(self, container):
         """Iniciar supervisord en el contenedor"""
         try:
             self.logger.info("Iniciando supervisord en sandbox local")
-            
+
             exit_code, output = container.exec_run(
                 cmd="/usr/bin/supervisord -n -c /etc/supervisor/conf.d/supervisord.conf",
                 detach=True
             )
-            
+
             # Note: For detached exec_run, exit_code might not be immediately useful
             # or might indicate the command was launched, not its completion status.
             # Consider logging output if available, but be aware it might be empty for detached processes.
@@ -167,7 +167,7 @@ class LocalSandbox:
 
         except Exception as e:
             self.logger.error(f"Error al iniciar supervisord: {str(e)}")
-    
+
     def _get_container_info(self, container):
         """Obtener información del contenedor"""
         container.reload()

--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from utils.logger import logger
 from utils.config import config
 from utils.config import Configuration
-from backend.sandbox.local_sandbox import local_sandbox
+from .local_sandbox import local_sandbox
 
 load_dotenv()
 
@@ -46,7 +46,7 @@ async def get_or_start_sandbox(sandbox_id: str):
         logger.info("Using Daytona for sandbox operations")
         try:
             sandbox = daytona.get_current_sandbox(sandbox_id)
-            
+
             # Check if sandbox needs to be started
             if sandbox.instance.state == WorkspaceState.ARCHIVED or sandbox.instance.state == WorkspaceState.STOPPED:
                 logger.info(f"Daytona sandbox is in {sandbox.instance.state} state. Starting...")
@@ -59,10 +59,10 @@ async def get_or_start_sandbox(sandbox_id: str):
                 except Exception as e:
                     logger.error(f"Error starting Daytona sandbox: {e}")
                     raise e
-            
+
             logger.info(f"Daytona sandbox {sandbox_id} is ready")
             return sandbox
-            
+
         except Exception as e:
             logger.error(f"Error retrieving or starting Daytona sandbox: {str(e)}")
             raise e
@@ -171,7 +171,7 @@ def create_sandbox(password: str, project_id: str = None):
         if project_id:
             logger.debug(f"Using project_id as label for Daytona sandbox: {project_id}")
             labels = {'id': project_id}
-            
+
         params = CreateSandboxParams(
             image=Configuration.SANDBOX_IMAGE_NAME, # Assuming Configuration.SANDBOX_IMAGE_NAME is also relevant for Daytona
             public=True,
@@ -196,17 +196,17 @@ def create_sandbox(password: str, project_id: str = None):
                 "disk": 5,
             }
         )
-        
+
         # Create the Daytona sandbox
         sandbox = daytona.create(params)
         logger.debug(f"Daytona sandbox created with ID: {sandbox.id}")
-        
+
         # Setup visualization environment (ensure this is Daytona compatible)
         setup_visualization_environment(sandbox)
 
         # Start supervisord in a session for new Daytona sandbox
         start_supervisord_session(sandbox)
-        
+
         logger.debug(f"Daytona sandbox environment successfully initialized")
         return sandbox
     else:

--- a/backend/tests/sandbox/test_sandbox_logic.py
+++ b/backend/tests/sandbox/test_sandbox_logic.py
@@ -56,7 +56,7 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
     @patch('backend.sandbox.sandbox.use_daytona') # Mock the function itself
     async def test_get_or_start_sandbox_daytona_running(self, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord):
         mock_use_daytona_func.return_value = True
-        
+
         mock_daytona_sandbox_instance = MagicMock()
         mock_daytona_sandbox_instance.instance.state = WorkspaceState.RUNNING
         mock_daytona_client.get_current_sandbox.return_value = mock_daytona_sandbox_instance
@@ -77,10 +77,10 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
     @patch('backend.sandbox.sandbox.use_daytona')
     async def test_get_or_start_sandbox_daytona_stopped_starts_it(self, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord):
         mock_use_daytona_func.return_value = True
-        
+
         initial_mock_sandbox = MagicMock()
         initial_mock_sandbox.instance.state = WorkspaceState.STOPPED
-        
+
         started_mock_sandbox = MagicMock() # Simulate state refresh after start
         started_mock_sandbox.instance.state = WorkspaceState.RUNNING
 
@@ -101,7 +101,7 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
     @patch('backend.sandbox.sandbox.use_daytona')
     async def test_get_or_start_sandbox_local_exists_running(self, mock_use_daytona_func, mock_ls_object, mock_logger):
         mock_use_daytona_func.return_value = False # Use local sandbox
-        
+
         mock_local_sandbox_instance = {
             'id': 'local-id-running',
             'container': MagicMock(),
@@ -123,7 +123,7 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
     @patch('backend.sandbox.sandbox.use_daytona')
     async def test_get_or_start_sandbox_local_exists_exited_starts_it(self, mock_use_daytona_func, mock_ls_object, mock_logger):
         mock_use_daytona_func.return_value = False
-        
+
         initial_local_sandbox = {
             'id': 'local-id-exited',
             'container': MagicMock(),
@@ -149,7 +149,7 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
         mock_use_daytona_func.return_value = False
         # Simulate local_sandbox.get_current_sandbox raising an error (e.g., docker.errors.NotFound)
         mock_ls_object.get_current_sandbox.side_effect = Exception("Simulated Docker Not Found")
-        
+
         created_local_sandbox = {
             'id': 'new-local-id',
             'container': MagicMock(),
@@ -176,19 +176,19 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
     async def test_create_sandbox_daytona_path(self, mock_configuration, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord, mock_setup_viz):
         mock_use_daytona_func.return_value = True
         mock_configuration.SANDBOX_IMAGE_NAME = "daytona/image:latest"
-        
+
         mock_created_daytona_sandbox = MagicMock()
         mock_daytona_client.create.return_value = mock_created_daytona_sandbox
 
         project_id = "daytona-proj-id"
         password = "secure_password"
-        
+
         result = create_sandbox(password=password, project_id=project_id) # create_sandbox is sync
 
         mock_daytona_client.create.assert_called_once_with(ANY) # ANY for CreateSandboxParams
         args, kwargs = mock_daytona_client.create.call_args
         created_params = args[0] # CreateSandboxParams is the first arg
-        
+
         self.assertEqual(created_params.image, "daytona/image:latest")
         self.assertEqual(created_params.labels, {'id': project_id})
         self.assertEqual(created_params.name, f"suna-sandbox-{project_id}")
@@ -210,7 +210,7 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
             'info': MagicMock(return_value={'state': 'running'})
         }
         mock_ls_object.create.return_value = mock_created_local_sandbox
-        
+
         project_id = "local-proj-id"
         password = "local_password"
 

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ def ask_execution_mode(state):
         print(f"\n{Colors.CYAN}Choose your sandbox execution mode:{Colors.ENDC}")
         print(f"{Colors.CYAN}[1] {Colors.GREEN}Daytona.io (Cloud Sandboxes){Colors.ENDC}")
         print(f"{Colors.CYAN}[2] {Colors.GREEN}Local Docker (Requires Docker installed and running){Colors.ENDC}\n")
-        
+
         choice = input("Enter your choice (1 for Daytona, 2 for Local Docker): ").strip()
         if choice == '1':
             state['execution_mode'] = 'daytona'
@@ -139,7 +139,7 @@ def ask_execution_mode(state):
             break
         else:
             print_error("Invalid choice. Please enter '1' or '2'.")
-    
+
     save_state(state)
     return state
 
@@ -148,23 +148,23 @@ def configure_local_docker(state):
     print_info("Local Docker execution mode has been selected and configured.")
     print_info("The setup process (specifically in the 'Installing dependencies' step) handles:")
     print_info("  - Ensuring the Docker SDK for Python is installed.")
-    
+
     # Retrieve the image name from state for the message, using the same logic as in install_dependencies
     DEFAULT_SANDBOX_IMAGE = 'kortix/suna:0.1.2.8'
     env_vars_combined = state.get('env_vars', {})
     llm_vars = env_vars_combined.get('llm', {})
     image_name = llm_vars.get('sandbox_image_name', DEFAULT_SANDBOX_IMAGE)
-    if not image_name: 
+    if not image_name:
         image_name = DEFAULT_SANDBOX_IMAGE
-        
+
     print_info(f"  - Checking for and attempting to pull the Suna sandbox image ('{image_name}').")
-    
+
     print_warning("\nCrucial Reminder for Local Docker Mode:")
     print_warning("  - Docker Desktop (on Windows/Mac) or the Docker daemon (on Linux) MUST be installed and RUNNING on your system.")
     print_warning("  - If Docker is not running, Suna will not be able to create local sandboxes.")
     print_info("\nIf Docker is running and the image is available, Suna will use local containers for agents.")
-    
-    # This function is primarily informational. 
+
+    # This function is primarily informational.
     # Clearing of Daytona env_vars is handled in main() before this is called.
     # Saving state is also handled in main() after this returns.
     return state
@@ -1468,7 +1468,7 @@ ENV_MODE=local
     # This key was previously in Daytona section, but makes more sense with LLM/general sandbox config.
     # It's used by local_sandbox.py
     # Defaulting to kortix/suna:0.1.2.8, ensure this is the desired default.
-    sandbox_image_name = env_vars.get('llm', {}).get('sandbox_image_name', 'kortix/suna:0.1.2.8') 
+    sandbox_image_name = env_vars.get('llm', {}).get('sandbox_image_name', 'kortix/suna:0.1.2.8')
     env_content += f"SANDBOX_IMAGE_NAME={sandbox_image_name}\n"
 
     if state and state.get('execution_mode') == 'daytona':
@@ -2009,7 +2009,7 @@ print(f'DEBUG_SUBPROCESS: shutil.which("pip"): {shutil.which("pip")}')
                 print_error(f"Could not connect to Docker daemon: {e_docker_service}")
                 print_warning("Please ensure Docker Desktop (or Docker service) is running and accessible.")
                 print_info(f"You may need to pull the sandbox image '{image_name if 'image_name' in locals() else DEFAULT_SANDBOX_IMAGE}' manually after starting Docker.")
-    
+
     return True # Return True assuming primary dependencies (npm, poetry) were successful
 
 def start_suna():
@@ -2397,7 +2397,7 @@ def main():
     check_requirements() # Python check within this should be fine now
     # Docker running check might be conditional if local mode is chosen, but good to check early
     # or ensure configure_local_docker handles it. For now, keep it here.
-    check_docker_running() 
+    check_docker_running()
     
     if not check_suna_directory():
         print_error("This setup script must be run from the Suna repository root directory.")
@@ -2480,9 +2480,9 @@ def main():
             print_info("Marking dependencies as installed in state.")
         else:
             print_error("Dependency installation failed. Exiting setup.")
-    elif installation_succeeded: 
+    elif installation_succeeded:
          print_info("Dependencies installation was skipped as it was previously completed.")
-    else: 
+    else:
         print_warning("install_dependencies was skipped but did not return True. Check logic.")
     save_state(state) # Save state after dependency install attempt/check
     if not installation_succeeded and not dependencies_previously_installed:
@@ -2497,7 +2497,7 @@ def main():
     # Now ask how to start Suna
     # Step number for "Starting Suna" is now the last step, so total_steps
     print_step(total_steps, total_steps, "Starting Suna") # Use total_steps as current_step for the last one
-    use_docker_startup = start_suna() 
+    use_docker_startup = start_suna()
     
     # Update environment files if needed for non-Docker startup
     if not use_docker_startup:

--- a/test_setup_script_docker_logic.py
+++ b/test_setup_script_docker_logic.py
@@ -62,11 +62,11 @@ class TestSetupDockerLogic(unittest.TestCase):
         mock_docker_module.from_env.return_value = mock_docker_client
         mock_docker_client.ping.return_value = True # Docker daemon is responsive
         # client.images.get() succeeds, meaning image is found
-        mock_docker_client.images.get.return_value = MagicMock() 
+        mock_docker_client.images.get.return_value = MagicMock()
 
         # Simulate pip install docker already done or successful
         mock_subprocess_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
-        
+
         # Act
         install_dependencies(state=self.mock_state, dependencies_installed=False)
 
@@ -88,12 +88,12 @@ class TestSetupDockerLogic(unittest.TestCase):
         mock_docker_client = MagicMock()
         mock_docker_module.from_env.return_value = mock_docker_client
         mock_docker_client.ping.return_value = True
-        
+
         image_name = self.mock_state['env_vars']['llm']['sandbox_image_name']
         # First call to images.get (check) raises ImageNotFound
         # Second call to images.get (verify after pull) succeeds
         mock_docker_client.images.get.side_effect = [
-            docker_errors.ImageNotFound("Image not found locally"), 
+            docker_errors.ImageNotFound("Image not found locally"),
             MagicMock() # Simulates image found after pull
         ]
         mock_docker_client.api.pull.return_value = [] # Simulate successful pull (empty log stream for simplicity)
@@ -128,7 +128,7 @@ class TestSetupDockerLogic(unittest.TestCase):
         mock_subprocess_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
 
         install_dependencies(state=self.mock_state, dependencies_installed=False)
-        
+
         mock_docker_client.api.pull.assert_called_once_with(image_name, stream=True, decode=True)
         mock_print_error.assert_any_call(f"Failed to pull image '{image_name}': Image not found in the registry.")
 
@@ -150,7 +150,7 @@ class TestSetupDockerLogic(unittest.TestCase):
         mock_subprocess_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
 
         install_dependencies(state=self.mock_state, dependencies_installed=False)
-        
+
         mock_docker_client.api.pull.assert_called_once_with(image_name, stream=True, decode=True)
         mock_print_error.assert_any_call(f"Failed to pull image '{image_name}': Docker API error: Docker API error during pull")
 
@@ -178,10 +178,10 @@ class TestSetupDockerLogic(unittest.TestCase):
     @patch('setup.subprocess.run')
     def test_execution_mode_not_local(self, mock_subprocess_run, mock_print_info, mock_docker_module):
         self.mock_state['execution_mode'] = 'daytona'
-        
+
         mock_docker_client = MagicMock()
         mock_docker_module.from_env.return_value = mock_docker_client
-        
+
         mock_subprocess_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
 
         install_dependencies(state=self.mock_state, dependencies_installed=False)
@@ -209,7 +209,7 @@ class TestSetupDockerLogic(unittest.TestCase):
         mock_docker_client = MagicMock()
         mock_docker_module.from_env.return_value = mock_docker_client
         mock_docker_client.ping.return_value = True
-        mock_docker_client.images.get.return_value = MagicMock() 
+        mock_docker_client.images.get.return_value = MagicMock()
 
         # Modify state to not include sandbox_image_name
         current_state = {
@@ -221,7 +221,7 @@ class TestSetupDockerLogic(unittest.TestCase):
         DEFAULT_IMAGE_IN_SETUP = 'kortix/suna:0.1.2.8' # Should match the default in install_dependencies
 
         mock_subprocess_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
-        
+
         install_dependencies(state=current_state, dependencies_installed=False)
 
         mock_docker_client.images.get.assert_called_once_with(DEFAULT_IMAGE_IN_SETUP)


### PR DESCRIPTION
I changed the import for `local_sandbox` within `backend/sandbox/sandbox.py` from `from backend.sandbox.local_sandbox import local_sandbox` to `from .local_sandbox import local_sandbox`.

This fixes a `ModuleNotFoundError` that occurred when running your backend in a Docker container, as the original import path was incorrect within the container's context where the `backend` directory is the root.