### PR TITLE
I've made a change to the backend requirements:

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -35,3 +35,4 @@ prometheus-client>=0.21.1
 langfuse>=2.60.5
 Pillow>=10.0.0
 sentry-sdk[fastapi]>=2.29.1
+docker>=6.0.0,<8.0.0


### PR DESCRIPTION
I added `docker>=6.0.0,<8.0.0` to `backend/requirements.txt`. This ensures that the Docker SDK for Python is installed in the `neura-backend` Docker container environment.

This is necessary for the `local_sandbox.py` module to function correctly when local Docker execution mode is enabled, as it needs to interact with the Docker daemon. This resolves a `ModuleNotFoundError: No module named 'docker'` that occurred if the main dependency installation step in `setup.py` was skipped (e.g., due to a saved setup state).