### PR TITLE
fix: Mount Docker socket into backend container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       - "8000:8000"
     volumes:
       - ./backend/.env:/app/.env:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     env_file:
       - ./backend/.env
     environment:


### PR DESCRIPTION
I modified `docker-compose.yaml` to mount the host's Docker socket (`/var/run/docker.sock`) into the `backend` service container.

This is necessary to allow the Docker SDK within the backend container (used by `local_sandbox.py`) to communicate with the host's Docker daemon, enabling the creation and management of local Docker sandboxes for agents. This resolves the `FileNotFoundError` for `docker.sock` that occurred when `docker.from_env()` was called.