### PR TITLE
fix: Add appuser to docker group in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,13 @@ RUN useradd -m -u 1000 appuser && \
 COPY --chown=appuser:appuser requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt gunicorn
 
+# Add appuser to docker group to allow Docker socket access
+RUN apt-get update && apt-get install -y --no-install-recommends shadow && \
+    groupadd -r docker || true && \
+    usermod -aG docker appuser && \
+    apt-get purge -y --auto-remove shadow && \
+    rm -rf /var/lib/apt/lists/*
+
 # Switch to non-root user
 USER appuser
 


### PR DESCRIPTION
I modified `backend/Dockerfile` to create a `docker` group and add `appuser` to this group. This is done before switching to `USER appuser`.

This change is intended to resolve `PermissionError: [Errno 13]` when the backend container tries to access your host's Docker socket mounted via `/var/run/docker.sock`. By being part of the `docker` group, `appuser` should have the necessary permissions to communicate with the Docker daemon for local sandbox management.