### PR TITLE
fix: Simplify appuser to docker group addition in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,11 +24,8 @@ COPY --chown=appuser:appuser requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt gunicorn
 
 # Add appuser to docker group to allow Docker socket access
-RUN apt-get update && apt-get install -y --no-install-recommends shadow && \
-    groupadd -r docker || true && \
-    usermod -aG docker appuser && \
-    apt-get purge -y --auto-remove shadow && \
-    rm -rf /var/lib/apt/lists/*
+RUN groupadd -r docker || true && \
+    usermod -aG docker appuser
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
I replaced the RUN command in `backend/Dockerfile` that installed the 'shadow' package and modified group membership. The new, simpler command `RUN groupadd -r docker || true && usermod -aG docker appuser` achieves the goal of adding appuser to the docker group, which is necessary for the backend service to interact with the mounted Docker socket.

This change resolves a build failure I encountered when the 'shadow' package could not be located in the python:3.11-slim base image, affecting services (like my own and potentially 'backend' on a clean build) that use this Dockerfile. The simplified command relies on `groupadd` and `usermod` being available in the base image, which is typical.