### PR TITLE
Fix: Run as root to resolve Docker socket permissions

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,6 +44,9 @@ ENV WORKER_CONNECTIONS=2000
 
 EXPOSE 8000
 
+# Switch to root user for the worker process
+USER root
+
 # Gunicorn configuration
 CMD ["sh", "-c", "gunicorn api:app \
      --workers $WORKERS \


### PR DESCRIPTION
I've modified the backend/Dockerfile to set USER root before the CMD instruction. This ensures that the process which initializes LocalSandbox and requires Docker access runs with root privileges within its container.

This change, in conjunction with mounting the Docker socket, is intended to resolve the PermissionError (errno 13) that was causing a crash upon attempting to connect to the Docker daemon.