### PR TITLE
Fix: Correct message list construction for LLM calls

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -191,7 +191,7 @@ async def run_agent(
                         detected_viz_type = detect_visualization_request(user_text_content)
                         if detected_viz_type:
                             logger.info(f"Detected visualization request: {detected_viz_type} in user message.")
-                            trace.event(name="visualization_request_detected", level="INFO", 
+                            trace.event(name="visualization_request_detected", level="DEFAULT",
                                         status_message=f"Type: {detected_viz_type}", 
                                         input={"user_message": user_text_content})
                             # Construct a system message to hint the LLM


### PR DESCRIPTION
- I've modified `backend/agentpress/thread_manager.py` to ensure that the `temporary_message` list (containing system hints or your context) is correctly extended into the main `final_messages_for_llm` list. This resolves an issue where a list containing a single hint message was being appended as a list-item itself, rather than its dictionary contents being added, leading to "AttributeError: 'list' object has no attribute 'get'" in litellm.
- I've also changed the type hint for `temporary_message` in `run_thread` to `Optional[List[Dict[str, Any]]]` to accurately reflect its usage.
- Finally, I corrected an invalid `level="INFO"` to `level="DEFAULT"` for a Langfuse event in `backend/agent/run.py`.