### PR TITLE
Okay, I've made a correction to address a TypeScript error in `fronte…

### DIFF
--- a/frontend/src/components/tasks/task-progress-view.tsx
+++ b/frontend/src/components/tasks/task-progress-view.tsx
@@ -181,7 +181,7 @@ const TaskProgressView: React.FC<TaskProgressViewProps> = ({ taskId }) => {
             <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-200 mb-4">Subtasks</h2>
 
             {/* Loading indicator for subtasks, shown only if no subtasks are currently displayed */}
-            {isLoadingSubtasks && (!Array.isArray(subtasks) || subtasks.length === 0) && (
+            {isLoadingSubtasks && (Array.isArray(subtasks) ? subtasks.length === 0 : true) && (
               <p className="text-gray-500 dark:text-gray-400">Loading subtasks...</p>
             )}
 


### PR DESCRIPTION
…nd/src/components/tasks/task-progress-view.tsx`. This error was related to how the loading indicator was being displayed.

It seems the error "'subtasks' is possibly 'undefined'" was happening because the code was trying to check the length of `subtasks` without being certain it was actually defined as an array.

I've adjusted the logic around line 184. Now, it uses a clearer check: `isLoadingSubtasks && (Array.isArray(subtasks) ? subtasks.length === 0 : true)`.

This change makes sure we only try to get the length of `subtasks` after confirming it's an array. This should fix the type error and make the loading indicator display more reliably.

This adjustment should help the frontend build successfully.