### PR TITLE
Fix: Correct syntax error in useAgentStream hook

### DIFF
--- a/frontend/src/hooks/useAgentStream.ts
+++ b/frontend/src/hooks/useAgentStream.ts
@@ -227,8 +227,7 @@ export function useAgentStream(
 
   // --- Stream Callback Handlers ---
 
-  const handleStreamMessage = useCallback(
-    useCallback((rawData: string) => {
+  const handleStreamMessage = useCallback((rawData: string) => {
       if (!isMountedRef.current) return;
       (window as any).lastStreamMessage = Date.now(); // Keep track of last message time
 
@@ -387,7 +386,7 @@ export function useAgentStream(
       callbacks,
       finalizeStream,
       updateStatus,
-    ],
+    ]
   );
 
   const handleStreamError = useCallback(


### PR DESCRIPTION
This commit fixes a syntax error in `frontend/src/hooks/useAgentStream.ts`. The `handleStreamMessage` function was incorrectly wrapped in a nested `useCallback`. The outer `useCallback` has been removed, resolving the "Expected ',', got ';'" error that caused the build to fail.