### PR TITLE
Fix: Address further ESLint errors and warnings

### DIFF
--- a/frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, Suspense, useEffect, useRef } from 'react';
+import React, { useState, Suspense, useEffect, useRef, useCallback } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useRouter } from 'next/navigation';
 import { Menu } from 'lucide-react';
@@ -49,7 +49,7 @@ function DashboardContent() {
   const secondaryGradient =
     'bg-gradient-to-r from-blue-500 to-blue-500 bg-clip-text text-transparent';
 
-  const handleSubmit = async (
+  const handleSubmit = useCallback(async (
     message: string,
     options?: {
       model_name?: string;
@@ -104,7 +104,7 @@ function DashboardContent() {
     } finally {
       setIsSubmitting(false);
     }
-  };
+  }, [isSubmitting, setIsSubmitting, initiateAgentMutation, router, onOpen, chatInputRef]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/frontend/src/components/file-renderers/markdown-renderer.tsx
+++ b/frontend/src/components/file-renderers/markdown-renderer.tsx
@@ -108,9 +108,9 @@ export const MarkdownRenderer = forwardRef<
               // For layout="responsive" or "intrinsic", width and height are needed.
               // Markdown typically doesn't provide these easily unless custom syntax is used.
               // Using placeholder values.
-              // @ts-ignore
+              // @ts-expect-error
               const width = node?.properties?.width || 500; // Placeholder
-              // @ts-ignore
+              // @ts-expect-error
               const height = node?.properties?.height || 300; // Placeholder
               const src = props.src || '';
               const alt = props.alt || '';

--- a/frontend/src/components/thread/file-attachment.tsx
+++ b/frontend/src/components/thread/file-attachment.tsx
@@ -324,7 +324,7 @@ export function FileAttachment({
                         console.log("Image loaded successfully:", filename);
                     }}
                     onError={(e) => {
-                        // @ts-ignore
+                        // @ts-expect-error
                         // Avoid logging the error for all instances of the same image
                         console.error('Image load error for:', filename);
 


### PR DESCRIPTION
This commit addresses additional ESLint issues identified from the build log:

- Changed `@ts-ignore` to `@ts-expect-error` in:
  - `src/components/file-renderers/markdown-renderer.tsx`
  - `src/components/thread/file-attachment.tsx` to comply with the `@typescript-eslint/ban-ts-comment` rule.

- Addressed `react-hooks/exhaustive-deps` in `src/app/(dashboard)/dashboard/page.tsx` by wrapping the `handleSubmit` function in `useCallback` and specifying its dependencies.

- Investigated other reported `react-hooks/exhaustive-deps` warnings in `src/hooks/react-query/files/use-file-queries.ts` and `src/hooks/use-cached-file.ts`. It seems these were previously addressed or the warnings might be misinterpreting stable external functions. I made no further changes to these files in this round.

- Investigated the `@next/next/no-img-element` warning in `src/components/file-renderers/image-renderer.tsx`. The identified `<img>` tag is a deliberate fallback within an `<object>` tag for SVG rendering. Replacing it with `next/image` is not appropriate for this specific fallback mechanism.