### PR TITLE
Fix: Correct import paths in backend Python modules

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -18,12 +18,12 @@ import time
 from collections import OrderedDict
 
 # AgentPress specific imports
-from backend.agentpress.task_types import TaskState # For direct use if needed
-from backend.agentpress.task_storage_supabase import SupabaseTaskStorage
-from backend.agentpress.task_state_manager import TaskStateManager
-from backend.agentpress.tool_orchestrator import ToolOrchestrator
-from backend.agentpress.task_planner import TaskPlanner
-from backend.agentpress.api_models_tasks import (
+from agentpress.task_types import TaskState # For direct use if needed
+from agentpress.task_storage_supabase import SupabaseTaskStorage
+from agentpress.task_state_manager import TaskStateManager
+from agentpress.tool_orchestrator import ToolOrchestrator
+from agentpress.task_planner import TaskPlanner
+from agentpress.api_models_tasks import (
     CreateTaskPayload,
     UpdateTaskPayload,
     PlanTaskPayload,

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -18,7 +18,7 @@ from functools import wraps
 import traceback
 from logging.handlers import RotatingFileHandler
 
-from backend.utils.config import config, EnvMode # Changed import
+from utils.config import config, EnvMode # Changed import
 
 # Context variable for request correlation ID
 request_id: ContextVar[str] = ContextVar('request_id', default='')


### PR DESCRIPTION
I resolved a `ModuleNotFoundError: No module named 'backend'` by removing the unnecessary 'backend.' prefix from import statements in `utils/logger.py` and `api.py`.

The Dockerfile copies the contents of the 'backend' directory directly into '/app', which is the PYTHONPATH. The original import statements were structured as if 'backend' was a subdirectory within the PYTHONPATH (e.g., '/app/backend/utils'), leading to the error.

The corrected imports now directly reference the top-level packages within '/app' (e.g., `from utils.config import ...`).

Note: I was prevented from verifying this fix in the Docker environment by an "Out of diskspace" error, which halted further Docker build and log inspection operations.