### PR TITLE
Fix: Resolve ModuleNotFoundError for backend.agentpress.task_types

### DIFF
--- a/backend/agentpress/task_storage_supabase.py
+++ b/backend/agentpress/task_storage_supabase.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Dict, Any
 import json
 from services.supabase import DBConnection
-from backend.agentpress.task_types import TaskState, TaskStorage
+from agentpress.task_types import TaskState, TaskStorage
 from utils.logger import logger
 
 class SupabaseTaskStorage(TaskStorage):


### PR DESCRIPTION
I changed the import statement in `backend/agentpress/task_storage_supabase.py` from `from backend.agentpress.task_types import TaskState, TaskStorage` to `from agentpress.task_types import TaskState, TaskStorage`.

This fixes a `ModuleNotFoundError` that occurred when you were running the application with Gunicorn inside a Docker container. The error was due to an incorrect absolute import path (`backend.agentpress...`) when the `backend` directory is treated as the root `/app` directory in the container. The corrected relative import (`agentpress...`) allows Python to locate the module correctly.