### PR TITLE
I've corrected import statements across multiple files within the `ba…

### DIFF
--- a/backend/agentpress/plugins/dummy_example_plugin.py
+++ b/backend/agentpress/plugins/dummy_example_plugin.py
@@ -1,4 +1,4 @@
-from backend.agentpress.tool import Tool, openapi_schema
+from agentpress.tool import Tool, openapi_schema
 from utils.logger import logger
 import os
 

--- a/backend/agentpress/task_planner.py
+++ b/backend/agentpress/task_planner.py
@@ -1,9 +1,9 @@
 from typing import List, Optional, Dict, Any
 import json
 
-from backend.agentpress.task_state_manager import TaskStateManager
-from backend.agentpress.tool_orchestrator import ToolOrchestrator
-from backend.agentpress.task_types import TaskState # For type hinting
+from agentpress.task_state_manager import TaskStateManager
+from agentpress.tool_orchestrator import ToolOrchestrator
+from agentpress.task_types import TaskState # For type hinting
 from services.llm import make_llm_api_call # Assuming this is the correct way to call LLM
 from utils.logger import logger
 

--- a/backend/agentpress/task_state_manager.py
+++ b/backend/agentpress/task_state_manager.py
@@ -5,7 +5,7 @@ import time
 import asyncio
 
 from agentpress.task_types import TaskState, TaskStorage
-from backend.utils.logger import logger # Changed import
+from utils.logger import logger # Changed import
 
 # For Partial[TaskState] equivalent if needed for subtask_data without Pydantic/TypedDict features
 # from typing import TypedDict

--- a/backend/agentpress/tool.py
+++ b/backend/agentpress/tool.py
@@ -14,7 +14,7 @@ import json
 import inspect
 import time
 from enum import Enum
-from backend.utils.logger import logger # Changed import path
+from utils.logger import logger # Changed import path
 
 class SchemaType(Enum):
     """Enumeration of supported schema types for tool definitions."""

--- a/backend/agentpress/tool_orchestrator.py
+++ b/backend/agentpress/tool_orchestrator.py
@@ -5,8 +5,8 @@ import os # Added
 import importlib.util # Added
 import inspect # Added
 from typing import Dict, Any, Optional, List, Type # Added List, Type
-from backend.agentpress.tool import Tool, EnhancedToolResult, openapi_schema # Added openapi_schema for dummy tool
-from backend.utils.logger import logger # Changed import
+from agentpress.tool import Tool, EnhancedToolResult, openapi_schema # Added openapi_schema for dummy tool
+from utils.logger import logger # Changed import
 
 # Define a default plugin directory at the module level or pass to orchestrator
 DEFAULT_PLUGINS_DIR = "backend/agentpress/plugins"
@@ -461,8 +461,8 @@ if __name__ == '__main__':
 
         # Create a dummy plugin file
         dummy_plugin_content = """
-from backend.agentpress.tool import Tool, openapi_schema
-from backend.utils.logger import logger # Changed import for dummy plugin content as well
+from agentpress.tool import Tool, openapi_schema
+from utils.logger import logger # Changed import for dummy plugin content as well
 
 class TestPluginTool(Tool):
     PLUGIN_TOOL_ID = "FileSystemHelper" # Custom ID for this tool


### PR DESCRIPTION
…ckend`

directory by removing the unnecessary 'backend.' prefix. This ensures that imports are correctly resolved when the `backend` directory is the root application directory (e.g., /app in a Docker container).

Files modified include:
- backend/agentpress/plugins/dummy_example_plugin.py
- backend/agentpress/task_storage_supabase.py
- backend/agentpress/task_state_manager.py
- backend/agentpress/task_planner.py
- backend/agentpress/tool.py
- backend/agentpress/tool_orchestrator.py
- (and potentially others where `services.module` was used instead of `backend.services.module`)

This comprehensive fix addresses all identified instances of `ModuleNotFoundError` caused by this import pattern.