### PR TITLE
Fix: Correct multiple syntax errors in thread_manager.py

### DIFF
--- a/backend/agentpress/thread_manager.py
+++ b/backend/agentpress/thread_manager.py
@@ -295,27 +295,27 @@ class ThreadManager:
                     from litellm import token_counter
                     # Use the potentially modified working_system_prompt for token counting
                     token_count = token_counter(model=llm_model, messages=[working_system_prompt] + messages)
-                        token_threshold = self.context_manager.token_threshold # Ensure this attribute exists or is defined
+                    token_threshold = self.context_manager.token_threshold # Ensure this attribute exists or is defined
                     logger.info(f"Thread {thread_id} token count: {token_count}/{token_threshold} ({(token_count/token_threshold)*100:.1f}%)")
 
-                        if token_count >= token_threshold and enable_context_manager:
-                            logger.info(f"Thread token count ({token_count}) exceeds threshold ({token_threshold}), summarizing...")
-                            summarized = await self.context_manager.check_and_summarize_if_needed(
-                                thread_id=thread_id,
-                                add_message_callback=self.add_message,
-                                model=llm_model,
-                                force=True # Consider if force should always be true here
-                            )
-                            if summarized:
-                                logger.info("Summarization complete, fetching updated messages with summary")
-                                messages = await self.get_llm_messages(thread_id)
-                                # Recount tokens after summarization, using the modified prompt
-                                new_token_count = token_counter(model=llm_model, messages=[working_system_prompt] + messages)
-                                logger.info(f"After summarization: token count reduced from {token_count} to {new_token_count}")
-                            else:
-                                logger.warning("Summarization failed or wasn't needed - proceeding with original messages")
-                        elif not enable_context_manager:
-                            logger.info("Automatic summarization disabled. Skipping token count check and summarization.")
+                    if token_count >= token_threshold and enable_context_manager:
+                        logger.info(f"Thread token count ({token_count}) exceeds threshold ({token_threshold}), summarizing...")
+                        summarized = await self.context_manager.check_and_summarize_if_needed(
+                            thread_id=thread_id,
+                            add_message_callback=self.add_message,
+                            model=llm_model,
+                            force=True # Consider if force should always be true here
+                        )
+                        if summarized:
+                            logger.info("Summarization complete, fetching updated messages with summary")
+                            messages = await self.get_llm_messages(thread_id)
+                            # Recount tokens after summarization, using the modified prompt
+                            new_token_count = token_counter(model=llm_model, messages=[working_system_prompt] + messages)
+                            logger.info(f"After summarization: token count reduced from {token_count} to {new_token_count}")
+                        else:
+                            logger.warning("Summarization failed or wasn't needed - proceeding with original messages")
+                    elif not enable_context_manager:
+                        logger.info("Automatic summarization disabled. Skipping token count check and summarization.")
 
                 except Exception as e:
                     logger.error(f"Error counting tokens or summarizing: {str(e)}")


### PR DESCRIPTION
I addressed several syntax issues in `backend/agentpress/thread_manager.py` that were preventing application startup:

1.  I corrected an `IndentationError` around line 298 related to the `token_threshold` assignment and subsequent block within the `_run_once` method. I unindented the affected lines to their correct levels.
2.  Previously, I fixed a `SyntaxError` (unterminated string literal) around line 241 by removing a misplaced static text block and commenting out a loop iterating over an undefined variable.

The entire file now compiles successfully with `python -m py_compile`.