### PR TITLE
Fix: Update Pydantic model config from orm_mode to from_attributes

### DIFF
--- a/backend/agentpress/api_models_tasks.py
+++ b/backend/agentpress/api_models_tasks.py
@@ -48,8 +48,7 @@ class TaskResponse(TaskStateBase):
     subtasks: List[str] = Field(default_factory=list) # IDs of subtasks
 
     class Config:
-        orm_mode = True # For compatibility if creating from ORM objects (like TaskState dataclass)
-        # Pydantic v2 uses `from_attributes = True`
+        from_attributes = True # For compatibility if creating from ORM objects (like TaskState dataclass)
 
 # Payload for the /plan endpoint
 class PlanTaskPayload(BaseModel):
@@ -84,7 +83,6 @@ class FullTaskStateResponse(BaseModel):
 
     class Config:
         from_attributes = True # Pydantic v2
-        # orm_mode = True # Pydantic v1
 
 class FullTaskListResponse(BaseModel):
     tasks: List[FullTaskStateResponse]


### PR DESCRIPTION
I've updated the Pydantic model configurations to be compatible with Pydantic V2. Specifically, I changed `orm_mode = True` to `from_attributes = True` in the `Config` class of the `TaskResponse` model in `backend/agentpress/api_models_tasks.py`.

This change addresses the UserWarning: "Valid config keys have changed in V2: * 'orm_mode' has been renamed to 'from_attributes'".

I also cleaned up redundant comments related to Pydantic versions in the same file for clarity.