### PR TITLE
Fix: Add DEV to EnvMode enum

### DIFF
--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -27,6 +27,7 @@ class EnvMode(Enum):
     LOCAL = "local"
     STAGING = "staging"
     PRODUCTION = "production"
+    DEV = "dev"
 
 class Configuration:
     """


### PR DESCRIPTION
The application was encountering an AttributeError because `EnvMode.DEV` was used in `backend/api.py` but was not a defined member of the `EnvMode` enum in `backend/utils/config.py`.

This commit adds `DEV` to the `EnvMode` enum to resolve the error.