### PR TITLE
Fix: Integrate Supabase service into Docker Compose and update docume…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,9 +5,26 @@
 ENV_MODE=local
 
 #DATABASE
-SUPABASE_URL=
-SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_URL=http://localhost:5432
+# For local Supabase setup via Docker, use the port mapped in docker-compose.yml.
+# If using a hosted Supabase instance, replace with your instance URL.
+
+SUPABASE_ANON_KEY=your_supabase_anon_key
+# Replace with your Supabase anonymous key.
+# For local setup, this is often a default value provided by Supabase Studio or CLI.
+# Example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
+
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+# Replace with your Supabase service role key.
+# This key has super admin privileges and should be kept secret.
+# For local setup, this is often a default value provided by Supabase Studio or CLI.
+# Example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.Mhr предполагается-RuleVALIDATE_JWT_SECRET_KEY_VALIDATE_JWT_SECRET_KEY_VALIDATE_JWT_SECRET_KEY_VALIDATE_JWT_SECRET_KEY
+
+# IMPORTANT: After setting up Supabase and configuring the above variables,
+# remember to run database migrations to create the necessary tables.
+# You can usually do this with the Supabase CLI:
+# supabase link --project-ref <your-project-ref>
+# supabase db push
 
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/backend/README.md
+++ b/backend/README.md
@@ -83,6 +83,44 @@ RABBITMQ_PORT=5672
 
 ---
 
+## Supabase Setup
+
+This project uses Supabase for its database. You can set it up locally using Docker or use a cloud-hosted Supabase instance.
+
+### Local Setup (Docker)
+
+1.  **Ensure Docker is running.**
+2.  **Configure Supabase in `backend/docker-compose.yml`:**
+    *   A Supabase service definition is included in `backend/docker-compose.yml`.
+    *   Make sure to set a strong password for `POSTGRES_PASSWORD` in this file.
+3.  **Configure Supabase connection details in `backend/.env`:**
+    *   Copy `backend/.env.example` to `backend/.env`.
+    *   Update `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` with the appropriate values for your local Supabase setup.
+        *   `SUPABASE_URL`: Typically `http://localhost:5432` if using the default port mapping.
+        *   `SUPABASE_ANON_KEY` and `SUPABASE_SERVICE_ROLE_KEY`: You can get these from the Supabase Studio (usually available at `http://localhost:8000` after starting Supabase) or via the Supabase CLI.
+4.  **Start all services:**
+    ```bash
+    cd backend
+    docker-compose up -d --build
+    ```
+5.  **Run database migrations:**
+    *   Install the Supabase CLI if you haven't already: `npm install supabase --save-dev` (or globally).
+    *   Link your local Supabase instance: `npx supabase link --project-ref <your-project-id>` (You can find `<your-project-id>` in `backend/supabase/config.toml` or when you initialize Supabase).
+    *   Apply migrations: `npx supabase db push`
+
+### Cloud-Hosted Supabase
+
+1.  **Create a Supabase project** on [supabase.com](https://supabase.com).
+2.  **Configure Supabase connection details in `backend/.env`:**
+    *   Copy `backend/.env.example` to `backend/.env`.
+    *   Update `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` with the values from your Supabase project settings.
+3.  **Run database migrations:**
+    *   Install the Supabase CLI.
+    *   Link your Supabase project: `npx supabase link --project-ref <your-project-ref>`
+    *   Apply migrations: `npx supabase db push`
+
+---
+
 ## Production Setup
 
 For production deployments, use the following command to set resource limits

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -17,6 +17,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+      supabase:
+        condition: service_healthy
     networks:
       - app-network
     environment:
@@ -54,6 +56,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+      supabase:
+        condition: service_healthy
     networks:
       - app-network
     environment:
@@ -68,6 +72,25 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  supabase:
+    image: supabase/postgres:15.1.0.118
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: your_strong_password # Replace with a strong password
+      POSTGRES_USER: supabase
+      POSTGRES_DB: postgres
+    volumes:
+      - supabase_data:/var/lib/postgresql/data
+    networks:
+      - app-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U supabase -d postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
@@ -120,3 +143,4 @@ networks:
 volumes:
   redis_data:
   rabbitmq_data:
+  supabase_data:


### PR DESCRIPTION
…ntation

This commit addresses an issue where the backend services could not connect to Supabase due to a missing service definition in the Docker Compose configuration.

Changes include:

- Added a Supabase service to `backend/docker-compose.yml`. This ensures that Supabase is started with the other backend services and is accessible on the same network.
- Updated `backend/.env.example` to include default Supabase connection details for local development and added notes about running database migrations.
- Added a "Supabase Setup" section to `backend/README.md` providing clear instructions for setting up Supabase (both locally via Docker and using a cloud provider) and running database migrations.

With these changes, the backend services should now be able to connect to Supabase correctly, resolving the "relation public.tasks does not exist" errors, assuming Supabase is properly configured and migrations are run according to the updated documentation.