### PR TITLE
Fix: Use --include-all for supabase db push

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1745,7 +1745,7 @@ def setup_supabase(existing_config, state): # state is the global state object
         # Push database migrations
         print_info("Pushing database migrations...")
         subprocess.run(
-            ['supabase', 'db', 'push'],
+            ['supabase', 'db', 'push', '--include-all'],
             cwd=backend_dir,
             check=True, # Raises SubprocessError on failure
             shell=IS_WINDOWS


### PR DESCRIPTION
This commit updates the `setup.py` script to include the `--include-all` flag when running `supabase db push`.

This change addresses an issue where `supabase db push` could fail if local migration files need to be inserted before the last migration already present on your remote Supabase database. The Supabase CLI itself suggests using this flag in such scenarios.

By adding `--include-all`, the migration process becomes more robust for you when setting up the project under these specific conditions.