### PR TITLE
Fix: Automate Supabase DB push confirmation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1745,7 +1745,7 @@ def setup_supabase(existing_config, state): # state is the global state object
         # Push database migrations
         print_info("Pushing database migrations...")
         subprocess.run(
-            ['supabase', 'db', 'push', '--include-all'],
+            ['supabase', 'db', 'push', '--include-all', '-y'], # Added -y
             cwd=backend_dir,
             check=True, # Raises SubprocessError on failure
             shell=IS_WINDOWS


### PR DESCRIPTION
This commit updates the `setup.py` script to add the `-y` flag (equivalent to `--yes`) to the `supabase db push --include-all` command.

This change prevents the Supabase CLI from pausing and waiting for interactive confirmation from you when pushing database migrations. Automating this step makes the setup process smoother and less prone to hanging if run in a non-interactive environment or if you are not expecting a prompt.