### PR TITLE
Fix: Remove invalid -y flag from supabase db push

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1745,7 +1745,7 @@ def setup_supabase(existing_config, state): # state is the global state object
         # Push database migrations
         print_info("Pushing database migrations...")
         subprocess.run(
-            ['supabase', 'db', 'push', '--include-all', '-y'], # Added -y
+            ['supabase', 'db', 'push', '--include-all'],
             cwd=backend_dir,
             check=True, # Raises SubprocessError on failure
             shell=IS_WINDOWS


### PR DESCRIPTION
This commit reverts a previous change that added a `-y` flag to the `supabase db push --include-all` command in `setup.py`.

The `-y` flag was intended to automate interactive confirmation but resulted in an "unknown shorthand flag" error for you, indicating incompatibility with your Supabase CLI version or the tool itself.

Removing the flag will cause the Supabase CLI to revert to its default behavior, which may include prompting you for confirmation interactively. This is preferable to the script failing due to an unrecognized CLI option.