### PR TITLE
Fix: Resolve errors in response processing and sandbox cleanup

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -331,7 +331,8 @@ async def run_agent_background(
                                 if use_daytona():
                                     response = await sandbox_instance.process.execute_session_command(cleanup_session_id, exec_req, timeout=60)
                                 else:
-                                    response = await sandbox_instance['process']['execute_session_command'](cleanup_session_id, exec_req, timeout=60)
+                                    # LocalSandbox's execute_session_command does not accept timeout
+                                    response = await sandbox_instance['process']['execute_session_command'](cleanup_session_id, exec_req)
 
                                 if response.exit_code == 0:
                                     logger.info(f"Cleanup command '{cmd}' successful.")


### PR DESCRIPTION
This commit addresses two specific errors identified from recent logs:

1.  **AttributeError in `response_processor.py`:**
    - Modified the `_add_tool_result` method in `backend/agentpress/response_processor.py` to return the full message dictionary object instead of just the message ID string.
    - Adjusted the calling code within `process_streaming_response` and `process_non_streaming_response` to correctly handle this dictionary when accessing `['message_id']` or passing the object to `format_for_yield`.
    - This resolves the `AttributeError: 'str' object has no attribute 'copy'` which occurred when `format_for_yield` received a string (message ID) instead of the expected message dictionary. It also ensures consistent handling of the `saved_tool_result_object`.

2.  **TypeError in `run_agent_background.py` for LocalSandbox cleanup:**
    - Removed the `timeout=60` keyword argument from the call to `sandbox_instance['process']['execute_session_command']` within the workspace cleanup logic for `LocalSandbox` (when `use_daytona()` is false).
    - This fixes the `TypeError: LocalSandbox.get_current_sandbox.<locals>.<lambda>() got an unexpected keyword argument 'timeout'`, as the local sandbox's command execution does not support this parameter.

These fixes enhance the robustness of backend stream processing and sandbox operations, contributing to overall application stability.