### PR TITLE
Fix: Correct IndentationError in run_agent_background.py

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -343,8 +343,8 @@ async def run_agent_background(
                                             logs = await sandbox_instance.process.get_session_command_logs(cleanup_session_id, response.cmd_id)
                                             logs_output = logs.stdout if logs and logs.stdout else (logs.stderr if logs and logs.stderr else "No output captured")
                                         else:
-                                        # LocalSandbox's get_session_command_logs is synchronous
-                                        logs = sandbox_instance['process']['get_session_command_logs'](cleanup_session_id, response.cmd_id)
+                                            # LocalSandbox's get_session_command_logs is synchronous
+                                            logs = sandbox_instance['process']['get_session_command_logs'](cleanup_session_id, response.cmd_id)
                                             logs_output = logs['stdout'] if logs and logs['stdout'] else (logs['stderr'] if logs and logs['stderr'] else "No output captured")
                                     except Exception as e_logs:
                                         logger.error(f"Error retrieving logs for failed cleanup command '{cmd}': {e_logs}")


### PR DESCRIPTION
I've resolved an `IndentationError: expected an indented block after 'else' statement` in the `run_agent_background.py` script.

The error occurred within the `finally` block's workspace cleanup logic, specifically in the section handling log retrieval for `LocalSandbox` instances (when `use_daytona()` is false). Lines responsible for fetching command logs were not correctly indented under their parent `else:` statement, likely due to a previous modification.

This commit corrects the indentation, allowing the Python interpreter to parse the file successfully. This is critical for enabling the backend API and services to start and operate correctly.