### PR TITLE
Refactor: Simplify system prompt selection logic in run_agent.py

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -146,16 +146,15 @@ async def run_agent(
         logger.debug("Tools initialized.")
 
         logger.debug(f"Generating system prompt for model: {model_name}...")
-        system_prompt_content = get_system_prompt()
-        if "anthropic" not in model_name.lower():
+        if "anthropic" in model_name.lower():
+            system_message = { "role": "system", "content": get_system_prompt() }
+            logger.debug("Using Anthropic system prompt (no sample response).")
+        else:
             sample_response_path = os.path.join(os.path.dirname(__file__), 'sample_responses/1.txt')
             with open(sample_response_path, 'r') as file:
                 sample_response = file.read()
-            system_prompt_content += "\n\n <sample_assistant_response>" + sample_response + "</sample_assistant_response>"
-            logger.debug("Using default system prompt with sample response.")
-        else:
-            logger.debug("Using Anthropic system prompt (no sample response).")
-        system_message = { "role": "system", "content": system_prompt_content }
+            system_message = { "role": "system", "content": get_system_prompt() + "\n\n <sample_assistant_response>" + sample_response + "</sample_assistant_response>" }
+            logger.debug(f"Using default system prompt with sample response for {model_name}.")
         logger.debug("System prompt generated.")
 
         logger.debug(f"Performing initial billing check for account {account_id}...")

--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -334,21 +334,21 @@ async def run_agent_background(
                                     # LocalSandbox's execute_session_command is synchronous and does not accept timeout
                                     response = sandbox_instance['process']['execute_session_command'](cleanup_session_id, exec_req)
 
-                                if response.exit_code == 0:
+                                if response['exit_code'] == 0:
                                     logger.info(f"Cleanup command '{cmd}' successful.")
                                 else:
                                     logs_output = "Could not retrieve logs." # Default if log retrieval fails
                                     try:
                                         if use_daytona():
-                                            logs = await sandbox_instance.process.get_session_command_logs(cleanup_session_id, response.cmd_id)
+                                            logs = await sandbox_instance.process.get_session_command_logs(cleanup_session_id, response['cmd_id'])
                                             logs_output = logs.stdout if logs and logs.stdout else (logs.stderr if logs and logs.stderr else "No output captured")
                                         else:
                                             # LocalSandbox's get_session_command_logs is synchronous
-                                            logs = sandbox_instance['process']['get_session_command_logs'](cleanup_session_id, response.cmd_id)
+                                            logs = sandbox_instance['process']['get_session_command_logs'](cleanup_session_id, response['cmd_id'])
                                             logs_output = logs['stdout'] if logs and logs['stdout'] else (logs['stderr'] if logs and logs['stderr'] else "No output captured")
                                     except Exception as e_logs:
                                         logger.error(f"Error retrieving logs for failed cleanup command '{cmd}': {e_logs}")
-                                    logger.warning(f"Cleanup command '{cmd}' failed. Exit: {response.exit_code}. Logs: {logs_output}")
+                                    logger.warning(f"Cleanup command '{cmd}' failed. Exit: {response['exit_code']}. Logs: {logs_output}")
                         except Exception as e_cleanup_ws:
                             logger.error(f"Error during workspace cleanup for sandbox {sandbox_id_for_cleanup_and_stop}: {e_cleanup_ws}", exc_info=True)
                         finally:


### PR DESCRIPTION
Ensures that non-Anthropic models consistently use the default system prompt with the sample response, and Anthropic models use the default system prompt without the sample response. This removes the overly specific 'gemini-2.5-flash' condition.