### PR TITLE
Fix: Correct SupabaseTaskStorage instantiation in planner flow

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -279,7 +279,8 @@ async def run_agent(
                         planning_process_orchestrator.load_tools_from_directory() # Load tools from the default plugin directory.
 
                         # TaskStateManager requires a storage backend.
-                        task_storage = SupabaseTaskStorage(db_client=client)
+                        # The `thread_manager.db` is the DBConnection instance.
+                        task_storage = SupabaseTaskStorage(db_connection=thread_manager.db)
                         task_manager = TaskStateManager(storage=task_storage)
                         await task_manager.initialize() # Initialize to load any existing task data if needed.
 


### PR DESCRIPTION
Resolves a TypeError that occurred during the instantiation of SupabaseTaskStorage within the keyword-triggered task planning logic in `backend/agent/run.py`.

The SupabaseTaskStorage constructor expects a `DBConnection` instance, but was being passed a raw Supabase client instance. This commit corrects the instantiation to pass the appropriate `DBConnection` object (available as `thread_manager.db` in that context).

This fix is critical for allowing the TaskPlanner and subsequently the PlanExecutor to be invoked correctly, enabling the delegation and execution pathway.