### PR TITLE
Fix: Correct SyntaxError in run_agent function signature

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -70,6 +70,7 @@ async def run_agent(
     thread_id: str,
     project_id: str,
     stream: bool,
+    tool_orchestrator: ToolOrchestrator, # CORRECTED PLACEMENT
     thread_manager: Optional[ThreadManager] = None,
     native_max_auto_continues: int = 25,
     max_iterations: int = 100,
@@ -77,7 +78,6 @@ async def run_agent(
     enable_thinking: Optional[bool] = False,
     reasoning_effort: Optional[str] = 'low',
     enable_context_manager: bool = True,
-    tool_orchestrator: ToolOrchestrator, # New parameter
     trace: Optional[StatefulTraceClient] = None
 ):
     """Run the development agent with specified configuration."""


### PR DESCRIPTION
I reordered parameters in the `run_agent` function in `backend/agent/run.py` to ensure that non-default arguments precede default arguments. This resolves the `SyntaxError: non-default argument follows default argument` that occurred due to the recent addition of the `tool_orchestrator` parameter.