### PR TITLE
Fix: Resolve ModuleNotFoundError for tool_orchestrator import

### DIFF
--- a/backend/agent/api.py
+++ b/backend/agent/api.py
@@ -23,7 +23,7 @@ from sandbox.sandbox import create_sandbox, get_or_start_sandbox
 from services.llm import make_llm_api_call
 from run_agent_background import run_agent_background, _cleanup_redis_response_list, update_agent_run_status
 from utils.constants import MODEL_NAME_ALIASES
-from backend.api import tool_orchestrator as global_tool_orchestrator
+from api import tool_orchestrator as global_tool_orchestrator
 # Initialize shared resources
 router = APIRouter()
 db = None


### PR DESCRIPTION
Corrected the import path for `tool_orchestrator` in `backend/agent/api.py`. Changed from `from backend.api import ...` to `from api import ...` to ensure the module is found correctly when running within the Docker container where the application's root is typically added to PYTHONPATH.

This addresses the `ModuleNotFoundError: No module named 'backend'` that occurred after previous modifications.