### PR TITLE
I've resolved a circular import issue.

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -83,7 +83,7 @@ async def lifespan(app: FastAPI):
 
         # Initialize other APIs (agent, sandbox, etc.)
         # Pass relevant initialized components if they need them
-        agent_api.initialize(db_connection, instance_id) # Assuming db_connection is what it needs
+        agent_api.initialize(db_connection, tool_orchestrator, instance_id)
         sandbox_api.initialize(db_connection)
         
         # Initialize Redis connection


### PR DESCRIPTION
I refactored how a part of my system accesses a global instance. Instead of a direct import, which caused a circular dependency, the instance is now passed as an argument during initialization and stored for later use.

This resolves an import error and ensures the correct instance is propagated.