### PR TITLE
Fix: Ensure correct PATH for sandbox command execution

### DIFF
--- a/backend/sandbox/local_sandbox.py
+++ b/backend/sandbox/local_sandbox.py
@@ -116,13 +116,15 @@ class LocalSandbox:
 
     def _execute_command(self, container, command_request):
         """Ejecutar un comando en el contenedor"""
+        STANDARD_PATH = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         try:
             cmd = command_request.command if hasattr(command_request, 'command') else command_request
             cwd = command_request.cwd if hasattr(command_request, 'cwd') else "/workspace"
 
             # Ejecutar el comando
             exit_code, output = container.exec_run(
-                cmd=f"cd {cwd} && {cmd}",
+                cmd=f"sh -c 'cd {cwd} && {cmd}'",
+                environment={"PATH": STANDARD_PATH},
                 stdout=True,
                 stderr=True
             )


### PR DESCRIPTION
This commit addresses issues where commands (including `cd` and Python probes) were failing with "command not found" (exit 127) during the cleanup phase in `run_agent_background.py` when using the local sandbox.

The primary changes are:

1.  **In `backend/sandbox/local_sandbox.py` (`_execute_command` method):**
    *   A `STANDARD_PATH = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"` is defined.
    *   The `container.exec_run()` call now uses the `environment={"PATH": STANDARD_PATH}` parameter. This ensures that all commands executed through `local_sandbox` have a sane and comprehensive PATH.
    *   Commands are also explicitly wrapped with `sh -c 'cd {cwd} && {cmd}'` for consistent shell behavior.

2.  **In `backend/run_agent_background.py` (cleanup section):**
    *   Removed the `STANDARD_PATH` definition (now handled by `local_sandbox.py`).
    *   Reverted the command strings for `echo $PATH`, `command -v`, Python probes, and Python script execution to their simpler forms, removing the `sh -c 'env PATH=...'` prefixes. This relies on `local_sandbox.py` now providing the correct environment.
    *   Ensured Python script string escaping is appropriate for direct execution via `python_executable -c "..."`.

These changes aim to make command execution within the local sandbox more robust by ensuring a proper `PATH` is always set, which should resolve the Python detection failures and allow the cleanup script to run as intended.