### PR TITLE
Fix: Correct quoting for Python probe commands in sandbox

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -426,10 +426,11 @@ print(f"Python cleanup script finished. Total files deleted: {files_deleted_coun
                                         cmd_v_logs_output = response_cmd_v.get('output', "").strip()
 
                                     python_path_from_cmd_v = cmd_v_logs_output.strip()
+                                    python_path_from_cmd_v = cmd_v_logs_output.strip()
                                     if python_path_from_cmd_v: # Check if not empty
                                         logger.info(f"'command -v' found Python at: {python_path_from_cmd_v}")
                                         # Verify this path works with a simple command
-                                        verify_cmd = f"{python_path_from_cmd_v} -c \"print('Python probe success via command -v')\"" # Reverted
+                                        verify_cmd = f"{python_path_from_cmd_v} -c \"print(\\'Python probe success via command -v\\')\"" # Escaped single quotes
                                         verify_req = SessionExecuteRequest(command=verify_cmd, var_async=False, cwd="/workspace")
                                         response_verify = None
                                         if use_daytona():
@@ -456,7 +457,7 @@ print(f"Python cleanup script finished. Total files deleted: {files_deleted_coun
                                 logger.info("Python not found via 'command -v', falling back to predefined list.") # Removed "with PATH"
                                 for exe_path in python_executables:
                                     logger.info(f"Probing for Python interpreter at: {exe_path}") # Removed "with PATH..."
-                                    test_cmd = f"{exe_path} -c \"print('Python probe success')\"" # Reverted
+                                    test_cmd = f"{exe_path} -c \"print(\\'Python probe success\\')\"" # Escaped single quotes
                                     probe_req = SessionExecuteRequest(command=test_cmd, var_async=False, cwd="/workspace")
                                     try:
                                         if use_daytona():


### PR DESCRIPTION
The Python probe commands (e.g., `python3 -c "print('text')"`) in `run_agent_background.py` were causing shell syntax errors ("Unterminated quoted string") when executed by `local_sandbox.py`. This was because `local_sandbox.py` wraps commands with `sh -c 'cd /workspace && {cmd}'`, and the single quotes within the Python `print` statement were not properly escaped for this outer shell context.

This commit modifies the Python probe commands in `run_agent_background.py` to escape the inner single quotes (e.g., changing `print('text')` to `print(\'text\')` within the command string passed to `python -c`). This ensures the command is correctly parsed by both the outer shell and the Python interpreter.

This fix, combined with the previous change to set a standard PATH in `local_sandbox.py`, aims to make Python detection and script execution during sandbox cleanup reliable.