### PR TITLE
Refine: Correct Python command quoting for sandbox execution

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -430,7 +430,7 @@ print(f"Python cleanup script finished. Total files deleted: {files_deleted_coun
                                     if python_path_from_cmd_v: # Check if not empty
                                         logger.info(f"'command -v' found Python at: {python_path_from_cmd_v}")
                                         # Verify this path works with a simple command
-                                        verify_cmd = f"{python_path_from_cmd_v} -c \"print(\\'Python probe success via command -v\\')\"" # Escaped single quotes
+                                        verify_cmd = f"{python_path_from_cmd_v} -c \"print('Python probe success via command -v')\"" # Corrected: Unescaped single quotes
                                         verify_req = SessionExecuteRequest(command=verify_cmd, var_async=False, cwd="/workspace")
                                         response_verify = None
                                         if use_daytona():
@@ -457,7 +457,7 @@ print(f"Python cleanup script finished. Total files deleted: {files_deleted_coun
                                 logger.info("Python not found via 'command -v', falling back to predefined list.") # Removed "with PATH"
                                 for exe_path in python_executables:
                                     logger.info(f"Probing for Python interpreter at: {exe_path}") # Removed "with PATH..."
-                                    test_cmd = f"{exe_path} -c \"print(\\'Python probe success\\')\"" # Escaped single quotes
+                                    test_cmd = f"{exe_path} -c \"print('Python probe success')\"" # Corrected: Unescaped single quotes
                                     probe_req = SessionExecuteRequest(command=test_cmd, var_async=False, cwd="/workspace")
                                     try:
                                         if use_daytona():


### PR DESCRIPTION
This commit refines the quoting of Python commands in `run_agent_background.py` to ensure they are correctly interpreted when executed by `local_sandbox.py`.

The previous iteration of fixes introduced Python SyntaxErrors because the probe commands (e.g., `print('text')`) were over-escaped for the new execution context provided by `local_sandbox.py`.

Changes in `run_agent_background.py`:
- Reverted Python probe commands (test_cmd, verify_cmd) to use standard Python string literals, e.g., `python_exe -c "print('text')"`. The escaping `\'` was removed.
- Ensured the main Python cleanup script execution also uses the standard `python_exe -c "escaped_script_content"` format, with `escaped_script_content` being escaped for double quotes.

This relies on `local_sandbox.py` now correctly invoking commands via `['/bin/sh', '-c', SCRIPT_STRING]` with the `PATH` set via the `environment` parameter. This combination should prevent both shell syntax errors and Python syntax errors related to command string parsing.