### PR TITLE
The following changes have been made to correct an indentation issue:

### DIFF
--- a/backend/agentpress/response_processor.py
+++ b/backend/agentpress/response_processor.py
@@ -329,9 +329,9 @@ class ResponseProcessor:
                 done, _ = await asyncio.wait(pending_tasks)
 
                 for execution in pending_tool_executions:
-                            # Log before tool execution (even if status already yielded)
-                            tool_call_details_string = f"Name='{execution['context'].function_name or execution['context'].xml_tag_name}', Args={execution['context'].tool_call.get('arguments', {})}"
-                            logger.info(f"Preparing to execute tool (streamed): {tool_call_details_string}")
+                    # Log before tool execution (even if status already yielded)
+                    tool_call_details_string = f"Name='{execution['context'].function_name or execution['context'].xml_tag_name}', Args={execution['context'].tool_call.get('arguments', {})}"
+                    logger.info(f"Preparing to execute tool (streamed): {tool_call_details_string}")
                     tool_idx = execution.get("tool_index", -1)
                     context = execution["context"]
                     # Check if status was already yielded during stream run


### PR DESCRIPTION
In the `process_streaming_response` method of `backend/agentpress/response_processor.py`, an IndentationError was occurring. This was caused by over-indented logging lines.

This fix aligns the indentation of these logging statements with the rest of the loop body, which should resolve the startup crash you were experiencing.