### PR TITLE
Input:

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -2,7 +2,7 @@ import os
 import json
 import re
 from uuid import uuid4
-from typing import Optional
+from typing import Optional, Any
 
 # from agent.tools.message_tool import MessageTool
 from agent.tools.message_tool import MessageTool

--- a/backend/agentpress/plan_executor.py
+++ b/backend/agentpress/plan_executor.py
@@ -404,15 +404,12 @@ Ensure your output is ONLY the valid JSON object of parameters, with no other te
         if agent_signaled_completion:
             final_main_task_status = "completed"
             final_main_task_message = completion_summary_from_agent
-            # logger.info(f"PLAN_EXECUTOR: Plan execution for main_task_id: {self.main_task_id} completed by agent signal.") # Replaced by more descriptive log below
         elif plan_failed:
             final_main_task_status = "failed"
             final_main_task_message = "Plan execution failed due to one or more subtask failures or deadlock."
-            # logger.error(f"PLAN_EXECUTOR: Plan execution for main_task_id: {self.main_task_id} failed.") # Replaced by more descriptive log below
         else: # All subtasks completed normally without explicit agent signal or failure
             final_main_task_status = "completed"
             final_main_task_message = "All subtasks processed successfully without explicit agent completion signal."
-            # logger.info(f"PLAN_EXECUTOR: Plan execution for main_task_id: {self.main_task_id} completed (all subtasks done).") # Replaced by more descriptive log below
 
         logger.info(f"PLAN_EXECUTOR: Plan execution for main_task_id: {self.main_task_id} finished with status '{final_main_task_status}'. Summary: {final_main_task_message}")
 


### PR DESCRIPTION
Hotfix: Import Any in agent/run.py to fix NameError

Resolves a `NameError: name 'Any' is not defined` in `backend/agent/run.py` by adding the necessary import from the `typing` module. The error occurred in the type hint for the `plan_executor_message_callback` function.

Output:
I've applied a hotfix to `agent/run.py` to resolve a `NameError`.

This addresses a `NameError: name 'Any' is not defined` in `backend/agent/run.py` by including the required import from the `typing` module. The error was happening in the type hint for the `plan_executor_message_callback` function.