### PR TITLE
Fix: Correct ImportError for get_system_prompt in TaskPlanner

### DIFF
--- a/backend/agentpress/task_planner.py
+++ b/backend/agentpress/task_planner.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Dict, Any
 import json
 from pydantic import BaseModel, Field, ValidationError # Added imports
 
-from ..agent.prompt import get_system_prompt # Added import
+from agent.prompt import get_system_prompt # Added import
 from agentpress.task_state_manager import TaskStateManager
 from agentpress.tool_orchestrator import ToolOrchestrator
 from agentpress.task_types import TaskState # For type hinting


### PR DESCRIPTION
Reverted the previous relative import and corrected the import path for `get_system_prompt` in `backend/agentpress/task_planner.py` to `from agent.prompt import get_system_prompt`.

This addresses the `ImportError: attempted relative import beyond top-level package`
and the original `ModuleNotFoundError: No module named 'backend'`.

The change assumes that `agent` and `agentpress` are discoverable as top-level packages/modules from the application root (e.g., `/app` in the Docker environment), which is consistent with the Gunicorn execution context and error messages.