### PR TITLE
Fix: Import Callable from typing in plan_executor

### DIFF
--- a/backend/agentpress/plan_executor.py
+++ b/backend/agentpress/plan_executor.py
@@ -5,7 +5,7 @@ The PlanExecutor iterates through subtasks, respecting their dependencies,
 and uses an LLM to determine parameters for assigned tools, then executes them
 via the ToolOrchestrator.
 """
-from typing import Optional, List, Dict, Any, AsyncGenerator # Updated imports
+from typing import Optional, List, Dict, Any, AsyncGenerator, Callable # Updated imports
 import json
 import uuid
 import asyncio # Added import


### PR DESCRIPTION
Resolves a NameError that occurred because `Callable` was used as a type hint in `backend/agentpress/plan_executor.py` without being imported from the `typing` module.

This commit adds `Callable` to the list of imports from `typing` in the specified file.