### PR TITLE
Fix: Resolve TypeError in PlanExecutor instantiation

### DIFF
--- a/backend/agentpress/thread_manager.py
+++ b/backend/agentpress/thread_manager.py
@@ -62,8 +62,7 @@ class ThreadManager:
         plan_executor_instance = PlanExecutor(
             main_task_id="dummy_json_plan_runner", # Placeholder, not used by execute_json_plan
             task_manager=task_manager_for_plan_executor,
-            tool_orchestrator=self.tool_orchestrator,
-            user_message_callback=None # Not used by execute_json_plan via ResponseProcessor
+        tool_orchestrator=self.tool_orchestrator
         )
 
         self.response_processor = ResponseProcessor(


### PR DESCRIPTION
The PlanExecutor class was being instantiated with a `user_message_callback` argument in `thread_manager.py`. However, this argument had been removed from the `PlanExecutor.__init__` method, leading to a `TypeError: PlanExecutor.__init__() got an unexpected keyword argument 'user_message_callback'`.

This commit removes the `user_message_callback` argument from the `PlanExecutor` instantiation in `backend/agentpress/thread_manager.py` to align with the updated class definition and resolve the error.