### PR TITLE
Fix: Set search_path for more Supabase functions

### DIFF
--- a/backend/supabase/migrations/20240414161707_basejump-setup.sql
+++ b/backend/supabase/migrations/20240414161707_basejump-setup.sql
@@ -97,7 +97,10 @@ create policy "Basejump settings can be read by authenticated users" on basejump
   This is not accessible from the outside, so can only be used inside postgres functions
  */
 CREATE OR REPLACE FUNCTION basejump.get_config()
-    RETURNS json AS
+    RETURNS json
+    LANGUAGE plpgsql
+    SET search_path = basejump
+AS
 $$
 DECLARE
     result RECORD;
@@ -105,7 +108,7 @@ BEGIN
     SELECT * from basejump.config limit 1 into result;
     return row_to_json(result);
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 grant execute on function basejump.get_config() to authenticated, service_role;
 
@@ -115,7 +118,10 @@ grant execute on function basejump.get_config() to authenticated, service_role;
   Check a specific boolean config value
  */
 CREATE OR REPLACE FUNCTION basejump.is_set(field_name text)
-    RETURNS boolean AS
+    RETURNS boolean
+    LANGUAGE plpgsql
+    SET search_path = basejump
+AS
 $$
 DECLARE
     result BOOLEAN;
@@ -123,7 +129,7 @@ BEGIN
     execute format('select %I from basejump.config limit 1', field_name) into result;
     return result;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 grant execute on function basejump.is_set(text) to authenticated;
 
@@ -133,7 +139,10 @@ grant execute on function basejump.is_set(text) to authenticated;
   * on tables
  */
 CREATE OR REPLACE FUNCTION basejump.trigger_set_timestamps()
-    RETURNS TRIGGER AS
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    SET search_path = basejump
+AS
 $$
 BEGIN
     if TG_OP = 'INSERT' then
@@ -145,7 +154,7 @@ BEGIN
     end if;
     RETURN NEW;
 END
-$$ LANGUAGE plpgsql;
+$$;
 
 
 /**
@@ -153,7 +162,10 @@ $$ LANGUAGE plpgsql;
   * on tables
  */
 CREATE OR REPLACE FUNCTION basejump.trigger_set_user_tracking()
-    RETURNS TRIGGER AS
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    SET search_path = basejump
+AS
 $$
 BEGIN
     if TG_OP = 'INSERT' then
@@ -165,7 +177,7 @@ BEGIN
     end if;
     RETURN NEW;
 END
-$$ LANGUAGE plpgsql;
+$$;
 
 /**
   basejump.generate_token(length)
@@ -174,13 +186,16 @@ $$ LANGUAGE plpgsql;
   how it's used
  */
 CREATE OR REPLACE FUNCTION basejump.generate_token(length int)
-    RETURNS text AS
+    RETURNS text
+    LANGUAGE sql
+    SET search_path = basejump
+AS
 $$
 select regexp_replace(replace(
                               replace(replace(replace(encode(gen_random_bytes(length)::bytea, 'base64'), '/', ''), '+',
                                               ''), '\', ''),
                               '=',
                               ''), E'[\\n\\r]+', '', 'g');
-$$ LANGUAGE sql;
+$$;
 
 grant execute on function basejump.generate_token(int) to authenticated;

--- a/backend/supabase/migrations/20240414161947_basejump-accounts.sql
+++ b/backend/supabase/migrations/20240414161947_basejump-accounts.sql
@@ -80,7 +80,10 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE basejump.accounts TO authenticated
  * primary_owner_user_id should be updated using the dedicated function
  */
 CREATE OR REPLACE FUNCTION basejump.protect_account_fields()
-    RETURNS TRIGGER AS
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    SET search_path = basejump
+AS
 $$
 BEGIN
     IF current_user IN ('authenticated', 'anon') THEN
@@ -96,7 +99,7 @@ BEGIN
 
     RETURN NEW;
 END
-$$ LANGUAGE plpgsql;
+$$;
 
 -- trigger to protect account fields
 CREATE TRIGGER basejump_protect_account_fields
@@ -107,7 +110,10 @@ EXECUTE FUNCTION basejump.protect_account_fields();
 
 -- convert any character in the slug that's not a letter, number, or dash to a dash on insert/update for accounts
 CREATE OR REPLACE FUNCTION basejump.slugify_account_slug()
-    RETURNS TRIGGER AS
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    SET search_path = basejump
+AS
 $$
 BEGIN
     if NEW.slug is not null then
@@ -116,7 +122,7 @@ BEGIN
 
     RETURN NEW;
 END
-$$ LANGUAGE plpgsql;
+$$;
 
 -- trigger to slugify the account slug
 CREATE TRIGGER basejump_slugify_account_slug

--- a/backend/supabase/migrations/20240414162100_basejump-invitations.sql
+++ b/backend/supabase/migrations/20240414162100_basejump-invitations.sql
@@ -47,14 +47,17 @@ EXECUTE FUNCTION basejump.trigger_set_timestamps();
   * accepting.  It allows us to avoid complex permissions on accounts
  */
 CREATE OR REPLACE FUNCTION basejump.trigger_set_invitation_details()
-    RETURNS TRIGGER AS
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    SET search_path = basejump
+AS
 $$
 BEGIN
     NEW.invited_by_user_id = auth.uid();
     NEW.account_name = (select name from basejump.accounts where id = NEW.account_id);
     RETURN NEW;
 END
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE TRIGGER basejump_trigger_set_invitation_details
     BEFORE INSERT

--- a/backend/supabase/migrations/20250416133920_agentpress_schema.sql
+++ b/backend/supabase/migrations/20250416133920_agentpress_schema.sql
@@ -292,6 +292,7 @@ CREATE OR REPLACE FUNCTION get_llm_formatted_messages(p_thread_id UUID)
 RETURNS JSONB
 SECURITY DEFINER -- Changed to SECURITY DEFINER to allow service role access
 LANGUAGE plpgsql
+SET search_path = public
 AS $$
 DECLARE
     messages_array JSONB := '[]'::JSONB;


### PR DESCRIPTION
I've explicitly set the search_path for additional PostgreSQL functions within Supabase migrations, primarily in the `basejump` schema and for `public.get_llm_formatted_messages`.

This addresses further instances of the `function_search_path_mutable` linting issue, ensuring these functions also operate within their intended schema contexts for improved security and reliability.