### PR TITLE
Fix: Correct TaskStateManager import path in run_agent

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -45,7 +45,7 @@ from agentpress.utils.json_helpers import extract_json_from_response
 # For now, I'll rely on existing mechanisms or what's available in ThreadManager.
 # If direct LLM calls or a different TaskStateManager are needed, the subtask might be underspecified for this file structure.
 from services.llm import make_llm_api_call # Adding as per prompt
-from backend.services.task_state_manager import TaskStateManager # This seems like the one from the prompt.
+from ..services.task_state_manager import TaskStateManager # Corrected import path
 
 load_dotenv()
 


### PR DESCRIPTION
The previous commit introduced an import for TaskStateManager in `backend/agent/run.py` as:
`from backend.services.task_state_manager import TaskStateManager`

This caused a `ModuleNotFoundError` because the application's working directory or PYTHONPATH setup prevented 'backend' from being recognized as a top-level package for this import.

This commit changes the import to a relative path: `from ..services.task_state_manager import TaskStateManager`

This resolves the import error and allows the application to start correctly.