### PR TITLE
Fix: Use direct import for TaskStateManager from agentpress

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -45,7 +45,7 @@ from agentpress.utils.json_helpers import extract_json_from_response
 # For now, I'll rely on existing mechanisms or what's available in ThreadManager.
 # If direct LLM calls or a different TaskStateManager are needed, the subtask might be underspecified for this file structure.
 from services.llm import make_llm_api_call # Adding as per prompt
-from ..agentpress.task_state_manager import TaskStateManager # Corrected import path to agentpress
+from agentpress.task_state_manager import TaskStateManager # Corrected import path to direct import
 
 load_dotenv()
 


### PR DESCRIPTION
The previous relative import `from ..agentpress.task_state_manager` in `backend/agent/run.py` resulted in an
`ImportError: attempted relative import beyond top-level package`.

This error indicates that the Python interpreter's path setup expects `agentpress` to be a top-level importable package from the context of `backend/agent/run.py`. This is consistent with other existing imports in the same file, such as
`from agentpress.plan_executor import PlanExecutor`.

This commit changes the import to a direct one:
`from agentpress.task_state_manager import TaskStateManager`

This should resolve the import error and allow the application to correctly locate the TaskStateManager module.