### PR TITLE
Fix: Correct SupabaseTaskStorage instantiation arguments

### DIFF
--- a/backend/run_agent_background.py
+++ b/backend/run_agent_background.py
@@ -132,7 +132,8 @@ async def run_agent_background(
             # Initialize TaskStateManager for this run
             logger.info(f"RUN_AGENT_BACKGROUND: Initializing TaskStateManager for agent_run_id: {agent_run_id}...")
             # db.client is the initialized Supabase client from `await db.initialize()`
-            task_storage = SupabaseTaskStorage(db_client=client) # Use 'client' which is db.client
+            # Corrected to use db_connection=db
+            task_storage = SupabaseTaskStorage(db_connection=db)
             local_task_state_manager = TaskStateManager(storage=task_storage)
             # Assuming initialize method exists and is async, as per prompt context
             # If TaskStateManager's initialize is not async, remove await


### PR DESCRIPTION
In `backend/run_agent_background.py`, `SupabaseTaskStorage` was being instantiated with an incorrect keyword argument `db_client`. The constructor for `SupabaseTaskStorage` expects the `DBConnection` instance to be passed via the `db_connection` keyword argument.

This commit changes the instantiation from:
  `task_storage = SupabaseTaskStorage(db_client=client)`
to:
  `task_storage = SupabaseTaskStorage(db_connection=db)`

This ensures `SupabaseTaskStorage` is initialized correctly, resolving the `TypeError` encountered during agent runs.