### PR TITLE
Fix: Correct TypeError in run_agent due to 'ascending' argument

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -164,7 +164,7 @@ async def run_agent(
         # Retrieve the initial prompt for planning
         initial_prompt_text = None
         # Fetch the earliest user message in the thread
-        first_user_message_query = await client.table('messages').select('content').eq('thread_id', thread_id).eq('type', 'user').order('created_at', ascending=True).limit(1).execute()
+        first_user_message_query = await client.table('messages').select('content').eq('thread_id', thread_id).eq('type', 'user').order('created_at', desc=False).limit(1).execute()
         
         if first_user_message_query.data:
             try:


### PR DESCRIPTION
The 'ascending' keyword argument in the .order() method call for Supabase client was causing a TypeError. This commit replaces 'ascending=True' with 'desc=False' to achieve the same ordering logic in a compatible way.

This resolves the issue where tasks initiated with a plan would not receive a response.