### PR TITLE
Fix: Correct AttributeError for set_status in TaskStateManager

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -189,7 +189,7 @@ async def run_agent(
             return # Exit run_agent
 
         # Step 1: Planning
-        await task_state_manager.set_status("running") # As per original prompt
+        await task_state_manager.set_task_status(task_id=thread_id, status="running") # As per original prompt
         await task_state_manager.add_message("Starting task...") # As per original prompt
         await task_state_manager.add_message("Phase 1: Planning...") # Log planning phase start
 


### PR DESCRIPTION
I replaced the incorrect call to `task_state_manager.set_status()` with the correct method `task_state_manager.set_task_status()` in `backend/agent/run.py`.

The previous call was causing an AttributeError because `set_status` is not a method of the `TaskStateManager` class. The `set_task_status` method requires a `task_id` (which is `thread_id` in this context) and a `status` string. This commit provides the necessary `task_id`.