### PR TITLE
Fix: Correct nested indentation errors in agent run script

### DIFF
--- a/backend/agent/run.py
+++ b/backend/agent/run.py
@@ -283,10 +283,10 @@ async def run_agent(
                     )
                     current_status_for_log = "completed"
 
-            await _add_task_log_message(task_state_manager, final_main_task_id, f"Phase 2 (Execution) concluded, status: {current_status_for_log}.")
+        await _add_task_log_message(task_state_manager, final_main_task_id, f"Phase 2 (Execution) concluded, status: {current_status_for_log}.")
 
-            langfuse.flush()
-            return
+        langfuse.flush()
+        return
 
     except Exception as e:
         logger.error(f"Error in run_agent orchestration for thread_id {thread_id}: {e}", exc_info=True)


### PR DESCRIPTION
This commit addresses further indentation issues identified after a previous fix in `backend/agent/run.py`. The original fix for an IndentationError inadvertently created a new one.

- Corrected an `IndentationError: unexpected indent` around line 267.
- Corrected a subsequent `IndentationError: unindent does not match any outer indentation level` around line 286.

These changes ensure the code block responsible for finalizing task status and logging is correctly structured within the main try-except block, which should resolve the Gunicorn boot failures.

Note: I attempted to run tests, but was blocked by project configuration and environment issues (ModuleNotFoundError for 'backend' package and Docker permission errors). These issues are separate from the indentation fixes and will require further investigation.