### PR TITLE
Fix: Add "use client" directive to layout.tsx

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { ThemeProvider } from '@/components/home/theme-provider';
 import { siteConfig } from '@/lib/site';
 import type { Metadata, Viewport } from 'next';


### PR DESCRIPTION
The `useEffect` hook was being used in `frontend/src/app/layout.tsx`, which is a Server Component by default in Next.js. This caused the build to fail.

This commit resolves the issue by adding the "use client" directive at the top of the file, marking it as a Client Component.