### PR TITLE
Fix: Use relative import for agentpress.task_types in backend API

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -19,7 +19,7 @@ import time
 from collections import OrderedDict
 
 # AgentPress specific imports
-from agentpress.task_types import TaskState # For direct use if needed
+from .agentpress.task_types import TaskState # For direct use if needed
 from agentpress.task_storage_supabase import SupabaseTaskStorage
 from agentpress.task_state_manager import TaskStateManager
 from agentpress.tool_orchestrator import ToolOrchestrator


### PR DESCRIPTION
Resolves a ModuleNotFoundError for 'agentpress.task_types' when running the backend API with Gunicorn. The issue was likely related to Python's sys.path configuration in the Dockerized Gunicorn environment.

Changed the import in `backend/api.py` from:
`from agentpress.task_types import TaskState`
to an explicit relative import:
`from .agentpress.task_types import TaskState`

This makes the import more robust by clearly indicating that 'agentpress' is a submodule within the same 'backend' package as 'api.py'.