### PR TITLE
I've adjusted `sys.path` in `backend/api.py` to make agentpress impor…

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -18,8 +18,17 @@ import uuid
 import time
 from collections import OrderedDict
 
+import sys
+import os
+# Ensure the script's directory (e.g., /app/) is in sys.path
+# to allow finding subpackages like 'agentpress'.
+# This is particularly for cases where api.py is run as a top-level script.
+script_dir = os.path.dirname(os.path.abspath(__file__))
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
+
 # AgentPress specific imports
-from .agentpress.task_types import TaskState # For direct use if needed
+from agentpress.task_types import TaskState # For direct use if needed
 from agentpress.task_storage_supabase import SupabaseTaskStorage
 from agentpress.task_state_manager import TaskStateManager
 from agentpress.tool_orchestrator import ToolOrchestrator


### PR DESCRIPTION
…ts more robust.

I reverted to absolute imports for the 'agentpress' package and added a mechanism to ensure the script's own directory is in `sys.path`. This should resolve 'ModuleNotFoundError' and 'ImportError' issues you might encounter when running `api.py` with Gunicorn in Docker, especially if `api.py` is treated as a top-level script and its directory isn't automatically set up for sub-package resolution.

Here's what I changed in `backend/api.py`:
1. I added a block to insert `os.path.dirname(os.path.abspath(__file__))` into `sys.path[0]` if it's not already there. I did this before any `agentpress` or `utils` imports.
2. I made sure all imports from the `agentpress` package (like `from agentpress.task_types import TaskState`) use the absolute module path from the perspective of the `backend` directory (which is treated as `/app` in the Docker context).