### PR TITLE
Fix: Resolve ModuleNotFoundError for 'backend' in Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -51,7 +51,7 @@ EXPOSE 8000
 USER root
 
 # Gunicorn configuration
-CMD ["sh", "-c", "gunicorn api:app \
+CMD ["sh", "-c", "gunicorn backend.api:app \
      --workers $WORKERS \
      --worker-class uvicorn.workers.UvicornWorker \
      --bind 0.0.0.0:8000 \


### PR DESCRIPTION
The Gunicorn command in the backend Dockerfile was incorrectly trying to run 'api:app' from the /app directory, leading to a ModuleNotFoundError because api.py is located in /app/backend/api.py.

This commit updates the Gunicorn CMD in backend/Dockerfile to 'backend.api:app', ensuring that the correct application entry point is used.

The existing sys.path manipulation within backend/api.py was reviewed and confirmed to be compatible with this change, as it correctly adds the /app directory to the Python path, allowing for proper module resolution (e.g., `from backend.services...`).