### PR TITLE
Fix: Explicitly set --pythonpath for Gunicorn in Docker

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -51,7 +51,7 @@ EXPOSE 8000
 USER root
 
 # Gunicorn configuration
-CMD ["sh", "-c", "gunicorn backend.api:app \
+CMD ["sh", "-c", "gunicorn --pythonpath /app backend.api:app \
      --workers $WORKERS \
      --worker-class uvicorn.workers.UvicornWorker \
      --bind 0.0.0.0:8000 \


### PR DESCRIPTION
Despite WORKDIR and PYTHONPATH being set to /app, Gunicorn was still unable to find the 'backend.api' module, resulting in a ModuleNotFoundError.

This commit modifies the Gunicorn CMD in backend/Dockerfile to include the '--pythonpath /app' argument. This explicitly directs Gunicorn to add /app to its Python module search path when locating the application module, which should resolve the import issue.