### PR TITLE
Refactor: Convert relative imports to absolute imports

### DIFF
--- a/backend/agent/tools/computer_use_tool.py
+++ b/backend/agent/tools/computer_use_tool.py
@@ -7,8 +7,8 @@ import logging
 from typing import Optional, Dict
 import os
 
-from ...agentpress.tool import Tool, ToolResult, openapi_schema, xml_schema
-from ...sandbox.tool_base import SandboxToolsBase, Sandbox
+from backend.agentpress.tool import Tool, ToolResult, openapi_schema, xml_schema
+from backend.sandbox.tool_base import SandboxToolsBase, Sandbox
 
 KEYBOARD_KEYS = [
     'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',

--- a/backend/agent/tools/data_providers_tool.py
+++ b/backend/agent/tools/data_providers_tool.py
@@ -1,13 +1,13 @@
 import json
 from typing import Dict, Any, List # For type hinting
 
-from ...agentpress.tool import Tool, openapi_schema, xml_schema # ToolResult removed
-from .data_providers.LinkedinProvider import LinkedinProvider
-from .data_providers.YahooFinanceProvider import YahooFinanceProvider
-from .data_providers.AmazonProvider import AmazonProvider
+from backend.agentpress.tool import Tool, openapi_schema, xml_schema # ToolResult removed
+from backend.agent.tools.data_providers.LinkedinProvider import LinkedinProvider
+from backend.agent.tools.data_providers.YahooFinanceProvider import YahooFinanceProvider
+from backend.agent.tools.data_providers.AmazonProvider import AmazonProvider
 import logging # Added for logging
-from .data_providers.ZillowProvider import ZillowProvider
-from .data_providers.TwitterProvider import TwitterProvider
+from backend.agent.tools.data_providers.ZillowProvider import ZillowProvider
+from backend.agent.tools.data_providers.TwitterProvider import TwitterProvider
 
 # Custom Exceptions
 class DataProvidersToolError(Exception):

--- a/backend/agent/tools/message_tool.py
+++ b/backend/agent/tools/message_tool.py
@@ -1,5 +1,5 @@
 from typing import List, Optional, Union, Dict, Any
-from ...agentpress.tool import Tool, openapi_schema, xml_schema # ToolResult removed
+from backend.agentpress.tool import Tool, openapi_schema, xml_schema # ToolResult removed
 import logging # Added for logging
 
 # Custom Exceptions

--- a/backend/agent/tools/python_tool.py
+++ b/backend/agent/tools/python_tool.py
@@ -1,6 +1,6 @@
-from ...agentpress.tool import openapi_schema, xml_schema
-from ...sandbox.tool_base import SandboxToolsBase
-from ...agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import openapi_schema, xml_schema
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.agentpress.thread_manager import ThreadManager
 from uuid import uuid4
 import logging # Added for logging
 
@@ -82,7 +82,7 @@ class PythonTool(SandboxToolsBase):
             # but for now, it ensures output is not held back.
             python_command = f"python -u -c \"{escaped_code}\""
 
-            from ...sandbox.sandbox import SessionExecuteRequest # Keep import local
+            from backend.sandbox.sandbox import SessionExecuteRequest # Keep import local
             req = SessionExecuteRequest(
                 command=python_command,
                 var_async=False,

--- a/backend/agent/tools/sb_browser_tool.py
+++ b/backend/agent/tools/sb_browser_tool.py
@@ -1,11 +1,11 @@
 import traceback
 import json
 
-from ...agentpress.tool import openapi_schema, xml_schema # ToolResult removed
-from ...agentpress.thread_manager import ThreadManager
-from ...sandbox.tool_base import SandboxToolsBase
-from ...utils.logger import logger
-from ...utils.s3_upload_utils import upload_base64_image
+from backend.agentpress.tool import openapi_schema, xml_schema # ToolResult removed
+from backend.agentpress.thread_manager import ThreadManager
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.utils.logger import logger
+from backend.utils.s3_upload_utils import upload_base64_image
 
 # Custom Exceptions
 class BrowserToolError(Exception):

--- a/backend/agent/tools/sb_deploy_tool.py
+++ b/backend/agent/tools/sb_deploy_tool.py
@@ -1,9 +1,9 @@
 import os
 from dotenv import load_dotenv
-from ...agentpress.tool import openapi_schema, xml_schema # ToolResult removed
-from ...sandbox.tool_base import SandboxToolsBase
-from ...utils.files_utils import clean_path
-from ...agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import openapi_schema, xml_schema # ToolResult removed
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.utils.files_utils import clean_path
+from backend.agentpress.thread_manager import ThreadManager
 
 # Load environment variables
 load_dotenv()

--- a/backend/agent/tools/sb_expose_tool.py
+++ b/backend/agent/tools/sb_expose_tool.py
@@ -1,6 +1,6 @@
-from ...agentpress.tool import openapi_schema, xml_schema # ToolResult removed
-from ...sandbox.tool_base import SandboxToolsBase
-from ...agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import openapi_schema, xml_schema # ToolResult removed
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.agentpress.thread_manager import ThreadManager
 import logging # Added for logging
 
 # Custom Exceptions

--- a/backend/agent/tools/sb_files_tool.py
+++ b/backend/agent/tools/sb_files_tool.py
@@ -1,9 +1,8 @@
-
-from ...agentpress.tool import ToolResult, openapi_schema, xml_schema
-from ...sandbox.tool_base import SandboxToolsBase
-from ...utils.files_utils import should_exclude_file, clean_path
-from ...agentpress.thread_manager import ThreadManager
-from ...utils.logger import logger
+from backend.agentpress.tool import ToolResult, openapi_schema, xml_schema
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.utils.files_utils import should_exclude_file, clean_path
+from backend.agentpress.thread_manager import ThreadManager
+from backend.utils.logger import logger
 import os
 import logging # Added for logging
 

--- a/backend/agent/tools/sb_shell_tool.py
+++ b/backend/agent/tools/sb_shell_tool.py
@@ -1,9 +1,9 @@
 from typing import Optional, Dict, Any
 import time
 from uuid import uuid4
-from ...agentpress.tool import openapi_schema, xml_schema # ToolResult removed
-from ...sandbox.tool_base import SandboxToolsBase
-from ...agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import openapi_schema, xml_schema # ToolResult removed
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.agentpress.thread_manager import ThreadManager
 import logging # Added for logging
 # Custom Exceptions
 class ShellToolError(Exception):

--- a/backend/agent/tools/sb_vision_tool.py
+++ b/backend/agent/tools/sb_vision_tool.py
@@ -5,9 +5,9 @@ from typing import Optional, Tuple
 from io import BytesIO
 from PIL import Image
 
-from ...agentpress.tool import openapi_schema, xml_schema # ToolResult removed
-from ...sandbox.tool_base import SandboxToolsBase
-from ...agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import openapi_schema, xml_schema # ToolResult removed
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.agentpress.thread_manager import ThreadManager
 # import json # Not used directly in this file after refactor
 import logging # Added for logging
 

--- a/backend/agent/tools/visualization_tool.py
+++ b/backend/agent/tools/visualization_tool.py
@@ -1,8 +1,8 @@
-from ...agentpress.tool import openapi_schema # ToolResult removed
-from ...sandbox.tool_base import SandboxToolsBase
-from ...agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import openapi_schema # ToolResult removed
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.agentpress.thread_manager import ThreadManager
 from uuid import uuid4
-from ...sandbox.sandbox import SessionExecuteRequest
+from backend.sandbox.sandbox import SessionExecuteRequest
 import logging # Added for logging
 
 # Custom Exceptions

--- a/backend/agent/tools/web_search_tool.py
+++ b/backend/agent/tools/web_search_tool.py
@@ -4,10 +4,10 @@ from dotenv import load_dotenv
 # ToolResult is not directly used by the methods anymore, but openapi_schema and xml_schema might be.
 # If they are only for ToolResult, they might not be needed either.
 # For now, keep openapi_schema and xml_schema if they are used by the class decorators.
-from ...agentpress.tool import openapi_schema, xml_schema
-from ...utils.config import config
-from ...sandbox.tool_base import SandboxToolsBase
-from ...agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import openapi_schema, xml_schema
+from backend.utils.config import config
+from backend.sandbox.tool_base import SandboxToolsBase
+from backend.agentpress.thread_manager import ThreadManager
 import json
 import os
 import datetime

--- a/backend/agentpress/context_manager.py
+++ b/backend/agentpress/context_manager.py
@@ -9,9 +9,9 @@ import json
 from typing import List, Dict, Any, Optional
 
 from litellm import token_counter, completion_cost
-from ..services.supabase import DBConnection
-from ..services.llm import make_llm_api_call
-from ..utils.logger import logger
+from backend.services.supabase import DBConnection
+from backend.services.llm import make_llm_api_call
+from backend.utils.logger import logger
 
 # Constants for token management
 DEFAULT_TOKEN_THRESHOLD = 120000  # 80k tokens threshold for summarization

--- a/backend/agentpress/plugins/__init__.py
+++ b/backend/agentpress/plugins/__init__.py
@@ -1,5 +1,5 @@
 # This file makes Python treat the 'plugins' directory as a package.
 # It can also be used for package-level initialization if needed in the future.
-from ...utils.logger import logger # Import the logger
+from backend.utils.logger import logger # Import the logger
 
 logger.info("AgentPress plugins package initialized.")

--- a/backend/agentpress/plugins/complete_tool.py
+++ b/backend/agentpress/plugins/complete_tool.py
@@ -1,4 +1,4 @@
-from ...agentpress.tool import Tool, ToolResult, openapi_schema
+from backend.agentpress.tool import Tool, ToolResult, openapi_schema
 from typing import Dict, Any
 import logging
 

--- a/backend/agentpress/plugins/dummy_example_plugin.py
+++ b/backend/agentpress/plugins/dummy_example_plugin.py
@@ -1,5 +1,5 @@
-from ...agentpress.tool import Tool, openapi_schema
-from ...utils.logger import logger
+from backend.agentpress.tool import Tool, openapi_schema
+from backend.utils.logger import logger
 import os
 
 class TestPluginTool(Tool):

--- a/backend/agentpress/task_planner.py
+++ b/backend/agentpress/task_planner.py
@@ -3,12 +3,12 @@ import json
 # Pydantic models will be defined below
 from pydantic import BaseModel, Field, ValidationError
 
-from ..agent.prompt import get_system_prompt
-from .task_state_manager import TaskStateManager
-from .tool_orchestrator import ToolOrchestrator
-from .task_types import TaskState # For type hinting
-from ..services.llm import make_llm_api_call # Assuming this is the correct way to call LLM
-from ..utils.logger import logger
+from backend.agent.prompt import get_system_prompt
+from backend.agentpress.task_state_manager import TaskStateManager
+from backend.agentpress.tool_orchestrator import ToolOrchestrator
+from backend.agentpress.task_types import TaskState # For type hinting
+from backend.services.llm import make_llm_api_call # Assuming this is the correct way to call LLM
+from backend.utils.logger import logger
 
 class TaskPlanner:
     """

--- a/backend/agentpress/task_state_manager.py
+++ b/backend/agentpress/task_state_manager.py
@@ -5,8 +5,8 @@ import time
 import asyncio
 import copy # Added for deepcopy
 
-from .task_types import TaskState, TaskStorage
-from ..utils.logger import logger # Changed import
+from backend.agentpress.task_types import TaskState, TaskStorage
+from backend.utils.logger import logger # Changed import
 
 # For Partial[TaskState] equivalent if needed for subtask_data without Pydantic/TypedDict features
 # from typing import TypedDict

--- a/backend/agentpress/task_storage_supabase.py
+++ b/backend/agentpress/task_storage_supabase.py
@@ -2,9 +2,9 @@ from typing import List, Optional, Dict, Any
 import json
 from datetime import datetime, timezone # Added
 # Removed APIError import
-from ..services.supabase import DBConnection
-from .task_types import TaskState, TaskStorage
-from ..utils.logger import logger
+from backend.services.supabase import DBConnection
+from backend.agentpress.task_types import TaskState, TaskStorage
+from backend.utils.logger import logger
 
 class SupabaseTaskStorage(TaskStorage):
     """

--- a/backend/agentpress/thread_manager.py
+++ b/backend/agentpress/thread_manager.py
@@ -12,21 +12,21 @@ This module provides comprehensive conversation management, including:
 
 import json
 from typing import List, Dict, Any, Optional, Type, Union, AsyncGenerator, Literal
-from ..services.llm import make_llm_api_call
-from .tool import Tool
-from .tool_orchestrator import ToolOrchestrator # Changed import
-from .context_manager import ContextManager
-from .response_processor import (
+from backend.services.llm import make_llm_api_call
+from backend.agentpress.tool import Tool
+from backend.agentpress.tool_orchestrator import ToolOrchestrator # Changed import
+from backend.agentpress.context_manager import ContextManager
+from backend.agentpress.response_processor import (
     ResponseProcessor,
     ProcessorConfig
 )
-from .plan_executor import PlanExecutor
-from .task_state_manager import TaskStateManager
-from .task_storage_supabase import SupabaseTaskStorage
-from ..services.supabase import DBConnection
-from ..utils.logger import logger
+from backend.agentpress.plan_executor import PlanExecutor
+from backend.agentpress.task_state_manager import TaskStateManager
+from backend.agentpress.task_storage_supabase import SupabaseTaskStorage
+from backend.services.supabase import DBConnection
+from backend.utils.logger import logger
 from langfuse.client import StatefulGenerationClient, StatefulTraceClient
-from ..services.langfuse import langfuse
+from backend.services.langfuse import langfuse
 import datetime
 
 # Type alias for tool choice

--- a/backend/agentpress/tool.py
+++ b/backend/agentpress/tool.py
@@ -14,7 +14,7 @@ import json
 import inspect
 import time
 from enum import Enum
-from ..utils.logger import logger # Changed import path
+from backend.utils.logger import logger # Changed import path
 
 class SchemaType(Enum):
     """Enumeration of supported schema types for tool definitions."""

--- a/backend/agentpress/tool_registry.py
+++ b/backend/agentpress/tool_registry.py
@@ -1,6 +1,6 @@
 from typing import Dict, Type, Any, List, Optional, Callable
-from .tool import Tool, SchemaType
-from ..utils.logger import logger
+from backend.agentpress.tool import Tool, SchemaType
+from backend.utils.logger import logger
 
 
 class ToolRegistry:

--- a/backend/agentpress/utils/message_assembler.py
+++ b/backend/agentpress/utils/message_assembler.py
@@ -3,7 +3,7 @@ import time
 
 # Try to import the project's logger, fall back to a basic one if not found during subtask execution.
 try:
-    from ...utils.logger import logger
+    from backend.utils.logger import logger
 except ImportError:
     import logging
     logger = logging.getLogger(__name__)

--- a/backend/sandbox/api.py
+++ b/backend/sandbox/api.py
@@ -6,10 +6,10 @@ from fastapi import FastAPI, UploadFile, File, HTTPException, APIRouter, Form, D
 from fastapi.responses import Response
 from pydantic import BaseModel
 
-from .sandbox import get_or_start_sandbox
-from ..utils.logger import logger
-from ..utils.auth_utils import get_optional_user_id
-from ..services.supabase import DBConnection
+from backend.sandbox.sandbox import get_or_start_sandbox
+from backend.utils.logger import logger
+from backend.utils.auth_utils import get_optional_user_id
+from backend.services.supabase import DBConnection
 
 # Initialize shared resources
 router = APIRouter(tags=["sandbox"])

--- a/backend/sandbox/local_sandbox.py
+++ b/backend/sandbox/local_sandbox.py
@@ -1,8 +1,8 @@
 import docker
 import uuid
 import os
-from ..utils.logger import logger
-from ..utils.config import config
+from backend.utils.logger import logger
+from backend.utils.config import config
 
 class LocalSandbox:
     def __init__(self):

--- a/backend/sandbox/sandbox.py
+++ b/backend/sandbox/sandbox.py
@@ -1,10 +1,10 @@
 from daytona_sdk import Daytona, DaytonaConfig, CreateSandboxParams, Sandbox, SessionExecuteRequest
 from daytona_api_client.models.workspace_state import WorkspaceState
 from dotenv import load_dotenv
-from ..utils.logger import logger
-from ..utils.config import config
-from ..utils.config import Configuration
-from .local_sandbox import local_sandbox
+from backend.utils.logger import logger
+from backend.utils.config import config
+from backend.utils.config import Configuration
+from backend.sandbox.local_sandbox import local_sandbox
 
 load_dotenv()
 

--- a/backend/sandbox/tool_base.py
+++ b/backend/sandbox/tool_base.py
@@ -1,12 +1,11 @@
-
 from typing import Optional
 
-from ..agentpress.thread_manager import ThreadManager
-from ..agentpress.tool import Tool
+from backend.agentpress.thread_manager import ThreadManager
+from backend.agentpress.tool import Tool
 from daytona_sdk import Sandbox
-from .sandbox import get_or_start_sandbox
-from ..utils.logger import logger
-from ..utils.files_utils import clean_path
+from backend.sandbox.sandbox import get_or_start_sandbox
+from backend.utils.logger import logger
+from backend.utils.files_utils import clean_path
 import json # Added for JSON parsing
 import asyncio # Added for asyncio.to_thread
 from typing import Dict, Any, Optional # Added for type hints

--- a/backend/services/billing.py
+++ b/backend/services/billing.py
@@ -8,12 +8,12 @@ from fastapi import APIRouter, HTTPException, Depends, Request
 from typing import Optional, Dict, Tuple
 import stripe
 from datetime import datetime, timezone
-from ..utils.logger import logger
-from ..utils.config import config, EnvMode
+from backend.utils.logger import logger
+from backend.utils.config import config, EnvMode
 from .supabase import DBConnection
-from ..utils.auth_utils import get_current_user_id_from_jwt
+from backend.utils.auth_utils import get_current_user_id_from_jwt
 from pydantic import BaseModel
-from ..utils.constants import MODEL_ACCESS_TIERS, MODEL_NAME_ALIASES
+from backend.utils.constants import MODEL_ACCESS_TIERS, MODEL_NAME_ALIASES
 # Initialize Stripe
 stripe.api_key = config.STRIPE_SECRET_KEY
 

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -17,8 +17,8 @@ import asyncio
 from unittest.mock import patch
 from openai import OpenAIError
 import litellm
-from ..utils.logger import logger
-from ..utils.config import config
+from backend.utils.logger import logger
+from backend.utils.config import config
 
 # litellm.set_verbose=True
 litellm.modify_params=True

--- a/backend/services/redis.py
+++ b/backend/services/redis.py
@@ -2,7 +2,7 @@ import redis.asyncio as redis
 import os
 from dotenv import load_dotenv
 import asyncio
-from ..utils.logger import logger
+from backend.utils.logger import logger
 from typing import List, Any
 
 # Redis client

--- a/backend/services/supabase.py
+++ b/backend/services/supabase.py
@@ -4,8 +4,8 @@ Centralized database connection management for AgentPress using Supabase.
 
 from typing import Optional
 from supabase import create_async_client, AsyncClient
-from ..utils.logger import logger
-from ..utils.config import config
+from backend.utils.logger import logger
+from backend.utils.config import config
 import base64
 import uuid
 from datetime import datetime

--- a/backend/services/transcription.py
+++ b/backend/services/transcription.py
@@ -4,8 +4,8 @@ import tempfile
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from pydantic import BaseModel
 from typing import Optional
-from ..utils.logger import logger
-from ..utils.auth_utils import get_current_user_id_from_jwt
+from backend.utils.logger import logger
+from backend.utils.auth_utils import get_current_user_id_from_jwt
 
 router = APIRouter(tags=["transcription"])
 


### PR DESCRIPTION
I've changed relative imports (e.g., `from ..utils.logger import logger`) to absolute imports (e.g., `from utils.logger import logger` or `from backend.utils.logger import logger`) within the backend directory.

This resolves `ImportError: attempted relative import beyond top-level package` by ensuring all imports are resolved from the project root (`/app`, which corresponds to the `backend` directory in this context).