### PR TITLE
Fix: Set PYTHONPATH in docker-compose for backend service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       - REDIS_SSL=False
       - RABBITMQ_HOST=rabbitmq
       - RABBITMQ_PORT=5672
+      - PYTHONPATH=/app
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
Adds `PYTHONPATH=/app` to the environment variables for the `backend` service in `docker-compose.yaml`.

This explicitly tells Python to include the `/app` directory in its module search path within the Docker container, resolving `ModuleNotFoundError` for top-level packages like `agentpress` when the application starts.