### PR TITLE
Fix: Relocate TaskState enum and update import to fix ModuleNotFoundE…

### DIFF
--- a/backend/agentpress/api_models_tasks.py
+++ b/backend/agentpress/api_models_tasks.py
@@ -1,3 +1,14 @@
+from enum import Enum
+
+# Pega el código aquí
+class TaskState(Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    ERROR = "error"
+    INTERRUPTED = "interrupted"
+    CANCELLED = "cancelled"
+
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 import uuid

--- a/backend/api.py
+++ b/backend/api.py
@@ -19,7 +19,7 @@ import time
 from collections import OrderedDict
 
 # AgentPress specific imports
-from agentpress.task_types import TaskState # For direct use if needed
+from agentpress.api_models_tasks import TaskState # For direct use if needed
 from agentpress.task_storage_supabase import SupabaseTaskStorage
 from agentpress.task_state_manager import TaskStateManager
 from agentpress.tool_orchestrator import ToolOrchestrator

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,15 +34,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     working_dir: /app
-    command: >
-      sh -c "
-        echo '--- Listing files in /app ---' &&
-        ls -lR /app &&
-        echo '--- PYTHONPATH value ---' &&
-        echo $PYTHONPATH &&
-        echo '--- Starting Gunicorn ---' &&
-        gunicorn api:app -w 4 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000
-      "
+    command: gunicorn api:app -w 4 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
…rror

- Moves the `TaskState` enum definition to `backend/agentpress/api_models_tasks.py`.
- Updates the import for `TaskState` in `backend/api.py` to point to its new location.
- Reverts the `command` in `docker-compose.yaml` for the backend service to the original Gunicorn startup command, removing the temporary debugging commands.

This is a workaround for the `ModuleNotFoundError: No module named 'agentpress.task_types'` by ensuring the `TaskState` definition is available in a file that is correctly included in the Docker image.