### PR TITLE
Fix: Consolidate task_types into api_models_tasks and update imports

### DIFF
--- a/backend/agentpress/api_models_tasks.py
+++ b/backend/agentpress/api_models_tasks.py
@@ -1,18 +1,101 @@
-from enum import Enum
-
-# Pega el código aquí
-class TaskState(Enum):
-    PENDING = "pending"
-    RUNNING = "running"
-    COMPLETED = "completed"
-    ERROR = "error"
-    INTERRUPTED = "interrupted"
-    CANCELLED = "cancelled"
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+import time
+from typing import List, Optional, Dict, Any, Set, Callable, Coroutine, TypedDict
+import uuid
 
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any
-import uuid
-import time
+
+# --- Content from backend/agentpress/task_types.py (excluding its original imports) ---
+
+# Using TypedDict for more precise dictionary structure if needed,
+# but dataclass is often easier to work with for state objects.
+# For now, let's use dataclass.
+
+@dataclass
+class TaskState:
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    name: str = ""
+    description: Optional[str] = None
+    status: str = "pending"  # e.g., pending, running, completed, failed, paused
+    progress: float = 0.0  # 0.0 to 1.0
+    startTime: float = field(default_factory=time.time)
+    endTime: Optional[float] = None
+    parentId: Optional[str] = None
+    subtasks: List[str] = field(default_factory=list)  # List of subtask IDs
+    dependencies: List[str] = field(default_factory=list)  # List of prerequisite task IDs
+    assignedTools: List[str] = field(default_factory=list) # Tools assigned or relevant to this task
+    artifacts: List[Dict[str, Any]] = field(default_factory=list)  # e.g., {"type": "file", "uri": "path/to/file.txt"}
+    metadata: Dict[str, Any] = field(default_factory=dict) # For any other custom data
+    error: Optional[str] = None # Error message if the task failed
+    result: Optional[Any] = None # Stores the outcome or product of the task
+
+class TaskStorage(ABC):
+    """
+    Abstract Base Class for task persistence.
+    Defines the interface for saving, loading, and deleting tasks.
+    """
+
+    @abstractmethod
+    async def save_task(self, task: TaskState) -> None:
+        """Persists a task state."""
+        pass
+
+    @abstractmethod
+    async def load_task(self, task_id: str) -> Optional[TaskState]:
+        """Loads a specific task state by its ID."""
+        pass
+
+    @abstractmethod
+    async def load_all_tasks(self) -> List[TaskState]:
+        """Loads all task states."""
+        pass
+
+    @abstractmethod
+    async def delete_task(self, task_id: str) -> None:
+        """Deletes a task state by its ID."""
+        pass
+
+    async def update_task(self, task_id: str, updates: Dict[str, Any]) -> Optional[TaskState]:
+        """
+        Atomically updates a task.
+        Default implementation loads, updates, and saves.
+        Subclasses can override for more efficient atomic updates if supported by the backend.
+        """
+        task = await self.load_task(task_id)
+        if task:
+            for key, value in updates.items():
+                if hasattr(task, key):
+                    setattr(task, key, value)
+                else:
+                    # Potentially handle updates to metadata or other dict fields more granularly
+                    # For now, direct attribute setting or error.
+                    # Consider adding to metadata if key not a direct attribute.
+                    # task.metadata[key] = value
+                    pass # Or raise an error for unknown fields
+            if "endTime" in updates and updates["endTime"] is None and task.status not in ["running", "pending", "paused"]:
+                 # If endTime is being cleared, it implies task is restarting or being reset.
+                 # However, endTime is usually set when a task concludes.
+                 pass
+            elif updates.get("status") in ["completed", "failed", "cancelled"] and not task.endTime:
+                task.endTime = updates.get("endTime", time.time())
+
+            await self.save_task(task)
+            return task
+        return None
+
+# Example of an artifact structure
+# class Artifact(TypedDict):
+#     type: str # e.g., 'file', 'url', 'text_snippet'
+#     uri: Optional[str] # path or url
+#     description: Optional[str]
+#     content: Optional[str] # for small text snippets
+
+# Example of how TaskState.subtasks and TaskState.dependencies would work:
+# If TaskA depends on TaskB, TaskA.dependencies would contain TaskB.id.
+# If TaskC is a subtask of TaskA, TaskA.subtasks would contain TaskC.id, and TaskC.parentId would be TaskA.id.
+
+# --- Original content from backend/agentpress/api_models_tasks.py (after its imports and removed Enum) ---
 
 # Re-using TaskState structure from backend/agentpress/task_types.py as a base
 # Pydantic models are often used for API validation and serialization.
@@ -20,7 +103,7 @@ import time
 class TaskStateBase(BaseModel):
     name: str
     description: Optional[str] = None
-    status: Optional[str] = "pending"
+    status: Optional[str] = "pending" # This will now refer to the string status from the dataclass TaskState
     progress: Optional[float] = 0.0
     parentId: Optional[str] = None
     # For creation, subtasks are usually not provided directly, but populated via add_subtask
@@ -79,7 +162,7 @@ class FullTaskStateResponse(BaseModel):
     id: str
     name: str
     description: Optional[str] = None
-    status: str
+    status: str # This should align with the string status from the TaskState dataclass
     progress: float
     startTime: float
     endTime: Optional[float] = None

--- a/backend/agentpress/plan_executor.py
+++ b/backend/agentpress/plan_executor.py
@@ -19,7 +19,7 @@ import asyncio
 from ..services import redis
 from .task_state_manager import TaskStateManager
 from .tool_orchestrator import ToolOrchestrator
-from .task_types import TaskState
+from .api_models_tasks import TaskState
 from .tool import ToolResult
 from .utils.json_helpers import format_for_yield
 from ..services.llm import make_llm_api_call

--- a/backend/agentpress/task_planner.py
+++ b/backend/agentpress/task_planner.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, ValidationError
 from backend.agent.prompt import get_system_prompt
 from backend.agentpress.task_state_manager import TaskStateManager
 from backend.agentpress.tool_orchestrator import ToolOrchestrator
-from backend.agentpress.task_types import TaskState # For type hinting
+from backend.agentpress.api_models_tasks import TaskState # For type hinting
 from backend.services.llm import make_llm_api_call # Assuming this is the correct way to call LLM
 from backend.utils.logger import logger
 

--- a/backend/agentpress/task_state_manager.py
+++ b/backend/agentpress/task_state_manager.py
@@ -5,7 +5,7 @@ import time
 import asyncio
 import copy # Added for deepcopy
 
-from agentpress.task_types import TaskState, TaskStorage
+from agentpress.api_models_tasks import TaskState, TaskStorage
 from utils.logger import logger # Changed import
 
 # For Partial[TaskState] equivalent if needed for subtask_data without Pydantic/TypedDict features

--- a/backend/agentpress/task_storage_supabase.py
+++ b/backend/agentpress/task_storage_supabase.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime, timezone # Added
 # Removed APIError import
 from services.supabase import DBConnection
-from agentpress.task_types import TaskState, TaskStorage
+from agentpress.api_models_tasks import TaskState, TaskStorage
 from utils.logger import logger
 
 class SupabaseTaskStorage(TaskStorage):


### PR DESCRIPTION
- I moved all content from `backend/agentpress/task_types.py` to the beginning of `backend/agentpress/api_models_tasks.py`.
- I globally updated imports from `agentpress.task_types` to `agentpress.api_models_tasks` within the `backend` directory.
- I verified that `docker-compose.yaml` uses the standard Gunicorn command for the backend service.

This resolves `ModuleNotFoundError: No module named 'agentpress.task_types'` by ensuring all necessary definitions are located in a module that is correctly included and found within the Docker environment.