### PR TITLE
I fixed import errors in the backend.

### DIFF
--- a/backend/agentpress/task_planner.py
+++ b/backend/agentpress/task_planner.py
@@ -3,12 +3,12 @@ import json
 # Pydantic models will be defined below
 from pydantic import BaseModel, Field, ValidationError
 
-from backend.agent.prompt import get_system_prompt
-from backend.agentpress.task_state_manager import TaskStateManager
-from backend.agentpress.tool_orchestrator import ToolOrchestrator
-from backend.agentpress.api_models_tasks import TaskState # For type hinting
-from backend.services.llm import make_llm_api_call # Assuming this is the correct way to call LLM
-from backend.utils.logger import logger
+from agent.prompt import get_system_prompt
+from agentpress.task_state_manager import TaskStateManager
+from agentpress.tool_orchestrator import ToolOrchestrator
+from agentpress.api_models_tasks import TaskState # For type hinting
+from services.llm import make_llm_api_call # Assuming this is the correct way to call LLM
+from utils.logger import logger
 
 class TaskPlanner:
     """

--- a/backend/agentpress/thread_manager.py
+++ b/backend/agentpress/thread_manager.py
@@ -12,21 +12,21 @@ This module provides comprehensive conversation management, including:
 
 import json
 from typing import List, Dict, Any, Optional, Type, Union, AsyncGenerator, Literal
-from backend.services.llm import make_llm_api_call
-from backend.agentpress.tool import Tool
-from backend.agentpress.tool_orchestrator import ToolOrchestrator # Changed import
-from backend.agentpress.context_manager import ContextManager
-from backend.agentpress.response_processor import (
+from services.llm import make_llm_api_call
+from agentpress.tool import Tool
+from agentpress.tool_orchestrator import ToolOrchestrator # Changed import
+from agentpress.context_manager import ContextManager
+from agentpress.response_processor import (
     ResponseProcessor,
     ProcessorConfig
 )
-from backend.agentpress.plan_executor import PlanExecutor
-from backend.agentpress.task_state_manager import TaskStateManager
-from backend.agentpress.task_storage_supabase import SupabaseTaskStorage
-from backend.services.supabase import DBConnection
-from backend.utils.logger import logger
+from agentpress.plan_executor import PlanExecutor
+from agentpress.task_state_manager import TaskStateManager
+from agentpress.task_storage_supabase import SupabaseTaskStorage
+from services.supabase import DBConnection
+from utils.logger import logger
 from langfuse.client import StatefulGenerationClient, StatefulTraceClient
-from backend.services.langfuse import langfuse
+from services.langfuse import langfuse
 import datetime
 
 # Type alias for tool choice

--- a/backend/agentpress/tool_orchestrator.py
+++ b/backend/agentpress/tool_orchestrator.py
@@ -6,7 +6,7 @@ import importlib.util # Added
 import inspect # Added
 from typing import Dict, Any, Optional, List, Type # Added List, Type
 from .tool import Tool, ToolResult, openapi_schema # Added openapi_schema for dummy tool
-from ..utils.logger import logger # Changed import
+from utils.logger import logger # Changed import
 
 # Define a default plugin directory at the module level or pass to orchestrator
 DEFAULT_PLUGINS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "plugins"))

--- a/backend/agentpress/utils/message_assembler.py
+++ b/backend/agentpress/utils/message_assembler.py
@@ -3,7 +3,7 @@ import time
 
 # Try to import the project's logger, fall back to a basic one if not found during subtask execution.
 try:
-    from backend.utils.logger import logger
+    from utils.logger import logger
 except ImportError:
     import logging
     logger = logging.getLogger(__name__)

--- a/backend/tests/agent/test_run_detection.py
+++ b/backend/tests/agent/test_run_detection.py
@@ -1,5 +1,5 @@
 import unittest
-from backend.agent.run import detect_visualization_request # Adjust import based on actual file structure
+from agent.run import detect_visualization_request # Adjust import based on actual file structure
 
 class TestDetectVisualizationRequest(unittest.TestCase):
 

--- a/backend/tests/agent/tools/test_python_tool.py
+++ b/backend/tests/agent/tools/test_python_tool.py
@@ -73,7 +73,7 @@ os.environ['ENV_MODE'] = 'local'
 
 
 # Now, these imports should succeed as Configuration() will find the env vars
-from backend.agent.tools.python_tool import PythonTool
+from agent.tools.python_tool import PythonTool
 from agentpress.tool import ToolResult
 
 

--- a/backend/tests/agentpress/test_task_planner.py
+++ b/backend/tests/agentpress/test_task_planner.py
@@ -2,10 +2,10 @@ import pytest
 import json
 from unittest.mock import AsyncMock, MagicMock, patch, call
 
-from backend.agentpress.task_planner import TaskPlanner, SubtaskDecompositionItem
-from backend.agentpress.task_state_manager import TaskStateManager
-from backend.agentpress.tool_orchestrator import ToolOrchestrator
-from backend.agentpress.task_types import TaskState # Assuming TaskState can be instantiated for mocking
+from agentpress.task_planner import TaskPlanner, SubtaskDecompositionItem
+from agentpress.task_state_manager import TaskStateManager
+from agentpress.tool_orchestrator import ToolOrchestrator
+from agentpress.task_types import TaskState # Assuming TaskState can be instantiated for mocking
 
 # Fixtures
 @pytest.fixture
@@ -55,7 +55,7 @@ async def test_plan_task_successful_decomposition(planner, mock_task_manager, mo
         {"name": "Sub2", "description": "D2", "dependencies": [0], "assigned_tools": ["T2"]}
     ]
 
-    with patch('backend.agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps(llm_response_json))) as mock_llm_call:
+    with patch('agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps(llm_response_json))) as mock_llm_call:
         result_main_task = await planner.plan_task("Test task")
 
         mock_llm_call.assert_called_once()
@@ -97,8 +97,8 @@ async def test_plan_task_llm_fails_json_parsing_after_retries(planner, mock_task
     mock_main_task = TaskState(id=main_task_id, name="Main task", description="Test", status="pending_planning", subtasks=[])
     mock_task_manager.create_task.return_value = mock_main_task
 
-    with patch('backend.agentpress.task_planner.make_llm_api_call', AsyncMock(return_value="invalid json string")) as mock_llm_call, \
-         patch('backend.agentpress.task_planner.logger.error') as mock_logger_error:
+    with patch('agentpress.task_planner.make_llm_api_call', AsyncMock(return_value="invalid json string")) as mock_llm_call, \
+         patch('agentpress.task_planner.logger.error') as mock_logger_error:
 
         result = await planner.plan_task("Test task json fail")
 
@@ -120,8 +120,8 @@ async def test_plan_task_llm_fails_pydantic_validation_after_retries(planner, mo
 
     invalid_pydantic_data = [{"description": "Missing name field"}] # name is required
 
-    with patch('backend.agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps(invalid_pydantic_data))) as mock_llm_call, \
-         patch('backend.agentpress.task_planner.logger.error') as mock_logger_error:
+    with patch('agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps(invalid_pydantic_data))) as mock_llm_call, \
+         patch('agentpress.task_planner.logger.error') as mock_logger_error:
 
         result = await planner.plan_task("Test task pydantic fail")
 
@@ -142,8 +142,8 @@ async def test_plan_task_llm_returns_empty_list(planner, mock_task_manager):
     mock_main_task = TaskState(id=main_task_id, name="Main task", description="Test", status="pending_planning", subtasks=[])
     mock_task_manager.create_task.return_value = mock_main_task
 
-    with patch('backend.agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps([]))) as mock_llm_call, \
-         patch('backend.agentpress.task_planner.logger.warning') as mock_logger_warning:
+    with patch('agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps([]))) as mock_llm_call, \
+         patch('agentpress.task_planner.logger.warning') as mock_logger_warning:
 
         result = await planner.plan_task("Test task empty list")
 
@@ -161,7 +161,7 @@ async def test_plan_task_llm_returns_empty_list(planner, mock_task_manager):
 async def test_plan_task_main_task_creation_fails(planner, mock_task_manager):
     mock_task_manager.create_task.return_value = None # Simulate main task creation failure
 
-    with patch('backend.agentpress.task_planner.make_llm_api_call', new_callable=AsyncMock) as mock_llm_call:
+    with patch('agentpress.task_planner.make_llm_api_call', new_callable=AsyncMock) as mock_llm_call:
         result = await planner.plan_task("Test task main fail")
 
         assert result is None
@@ -194,8 +194,8 @@ async def test_plan_task_subtask_creation_fails_partially(planner, mock_task_man
         {"name": "Sub2_fails", "description": "D2_fails", "dependencies": [0], "assigned_tools": ["T2"]}
     ]
 
-    with patch('backend.agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps(llm_response_json))) as mock_llm_call, \
-         patch('backend.agentpress.task_planner.logger.error') as mock_logger_error:
+    with patch('agentpress.task_planner.make_llm_api_call', AsyncMock(return_value=json.dumps(llm_response_json))) as mock_llm_call, \
+         patch('agentpress.task_planner.logger.error') as mock_logger_error:
 
         result_main_task = await planner.plan_task("Test partial")
 

--- a/backend/tests/agentpress/test_task_state_manager.py
+++ b/backend/tests/agentpress/test_task_state_manager.py
@@ -4,8 +4,8 @@ import time
 from typing import List, Optional, Dict, Any, Set, Callable, Coroutine
 import uuid
 
-from backend.agentpress.task_types import TaskState, TaskStorage
-from backend.agentpress.task_state_manager import TaskStateManager
+from agentpress.task_types import TaskState, TaskStorage
+from agentpress.task_state_manager import TaskStateManager
 
 # --- Mock TaskStorage Implementation ---
 class MockTaskStorage(TaskStorage):

--- a/backend/tests/sandbox/test_sandbox_logic.py
+++ b/backend/tests/sandbox/test_sandbox_logic.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock, ANY, call, AsyncMock
 import asyncio
 
 # Import the items to be tested
-from backend.sandbox.sandbox import use_daytona, get_or_start_sandbox, create_sandbox
+from sandbox.sandbox import use_daytona, get_or_start_sandbox, create_sandbox
 
 # Attempt to import WorkspaceState for Daytona tests
 try:
@@ -20,28 +20,28 @@ except ImportError:
 class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
 
     # --- Tests for use_daytona ---
-    @patch('backend.sandbox.sandbox.config')
+    @patch('sandbox.sandbox.config')
     def test_use_daytona_true_when_all_set(self, mock_config):
         mock_config.DAYTONA_API_KEY = "test_key"
         mock_config.DAYTONA_SERVER_URL = "http://test.server"
         mock_config.DAYTONA_TARGET = "test_target"
         self.assertTrue(use_daytona())
 
-    @patch('backend.sandbox.sandbox.config')
+    @patch('sandbox.sandbox.config')
     def test_use_daytona_false_if_api_key_missing(self, mock_config):
         mock_config.DAYTONA_API_KEY = None
         mock_config.DAYTONA_SERVER_URL = "http://test.server"
         mock_config.DAYTONA_TARGET = "test_target"
         self.assertFalse(use_daytona())
 
-    @patch('backend.sandbox.sandbox.config')
+    @patch('sandbox.sandbox.config')
     def test_use_daytona_false_if_server_url_missing(self, mock_config):
         mock_config.DAYTONA_API_KEY = "test_key"
         mock_config.DAYTONA_SERVER_URL = "" # Empty string
         mock_config.DAYTONA_TARGET = "test_target"
         self.assertFalse(use_daytona())
 
-    @patch('backend.sandbox.sandbox.config')
+    @patch('sandbox.sandbox.config')
     def test_use_daytona_false_if_target_missing(self, mock_config):
         mock_config.DAYTONA_API_KEY = "test_key"
         mock_config.DAYTONA_SERVER_URL = "http://test.server"
@@ -50,10 +50,10 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
 
     # --- Tests for get_or_start_sandbox ---
 
-    @patch('backend.sandbox.sandbox.start_supervisord_session') # Mock helper
-    @patch('backend.sandbox.sandbox.logger')
-    @patch('backend.sandbox.sandbox.daytona') # Mock daytona client instance
-    @patch('backend.sandbox.sandbox.use_daytona') # Mock the function itself
+    @patch('sandbox.sandbox.start_supervisord_session') # Mock helper
+    @patch('sandbox.sandbox.logger')
+    @patch('sandbox.sandbox.daytona') # Mock daytona client instance
+    @patch('sandbox.sandbox.use_daytona') # Mock the function itself
     async def test_get_or_start_sandbox_daytona_running(self, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord):
         mock_use_daytona_func.return_value = True
 
@@ -71,10 +71,10 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
         mock_logger.info.assert_any_call(f"Getting or starting sandbox with ID: {sandbox_id}")
         mock_logger.info.assert_any_call("Using Daytona for sandbox operations")
 
-    @patch('backend.sandbox.sandbox.start_supervisord_session')
-    @patch('backend.sandbox.sandbox.logger')
-    @patch('backend.sandbox.sandbox.daytona')
-    @patch('backend.sandbox.sandbox.use_daytona')
+    @patch('sandbox.sandbox.start_supervisord_session')
+    @patch('sandbox.sandbox.logger')
+    @patch('sandbox.sandbox.daytona')
+    @patch('sandbox.sandbox.use_daytona')
     async def test_get_or_start_sandbox_daytona_stopped_starts_it(self, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord):
         mock_use_daytona_func.return_value = True
 
@@ -96,9 +96,9 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
         mock_start_supervisord.assert_called_once_with(started_mock_sandbox)
         self.assertEqual(result, started_mock_sandbox)
 
-    @patch('backend.sandbox.sandbox.logger')
-    @patch('backend.sandbox.sandbox.local_sandbox') # Mock local_sandbox object
-    @patch('backend.sandbox.sandbox.use_daytona')
+    @patch('sandbox.sandbox.logger')
+    @patch('sandbox.sandbox.local_sandbox') # Mock local_sandbox object
+    @patch('sandbox.sandbox.use_daytona')
     async def test_get_or_start_sandbox_local_exists_running(self, mock_use_daytona_func, mock_ls_object, mock_logger):
         mock_use_daytona_func.return_value = False # Use local sandbox
 
@@ -118,9 +118,9 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, mock_local_sandbox_instance)
         mock_logger.info.assert_any_call("Using local sandbox for operations")
 
-    @patch('backend.sandbox.sandbox.logger')
-    @patch('backend.sandbox.sandbox.local_sandbox')
-    @patch('backend.sandbox.sandbox.use_daytona')
+    @patch('sandbox.sandbox.logger')
+    @patch('sandbox.sandbox.local_sandbox')
+    @patch('sandbox.sandbox.use_daytona')
     async def test_get_or_start_sandbox_local_exists_exited_starts_it(self, mock_use_daytona_func, mock_ls_object, mock_logger):
         mock_use_daytona_func.return_value = False
 
@@ -142,9 +142,9 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
         mock_ls_object.start.assert_called_once_with(initial_local_sandbox)
         self.assertEqual(result, started_local_sandbox)
 
-    @patch('backend.sandbox.sandbox.logger')
-    @patch('backend.sandbox.sandbox.local_sandbox')
-    @patch('backend.sandbox.sandbox.use_daytona')
+    @patch('sandbox.sandbox.logger')
+    @patch('sandbox.sandbox.local_sandbox')
+    @patch('sandbox.sandbox.use_daytona')
     async def test_get_or_start_sandbox_local_not_found_creates_new(self, mock_use_daytona_func, mock_ls_object, mock_logger):
         mock_use_daytona_func.return_value = False
         # Simulate local_sandbox.get_current_sandbox raising an error (e.g., docker.errors.NotFound)
@@ -167,12 +167,12 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
 
     # --- Tests for create_sandbox ---
 
-    @patch('backend.sandbox.sandbox.setup_visualization_environment')
-    @patch('backend.sandbox.sandbox.start_supervisord_session')
-    @patch('backend.sandbox.sandbox.logger')
-    @patch('backend.sandbox.sandbox.daytona')
-    @patch('backend.sandbox.sandbox.use_daytona')
-    @patch('backend.sandbox.sandbox.Configuration') # For Configuration.SANDBOX_IMAGE_NAME
+    @patch('sandbox.sandbox.setup_visualization_environment')
+    @patch('sandbox.sandbox.start_supervisord_session')
+    @patch('sandbox.sandbox.logger')
+    @patch('sandbox.sandbox.daytona')
+    @patch('sandbox.sandbox.use_daytona')
+    @patch('sandbox.sandbox.Configuration') # For Configuration.SANDBOX_IMAGE_NAME
     async def test_create_sandbox_daytona_path(self, mock_configuration, mock_use_daytona_func, mock_daytona_client, mock_logger, mock_start_supervisord, mock_setup_viz):
         mock_use_daytona_func.return_value = True
         mock_configuration.SANDBOX_IMAGE_NAME = "daytona/image:latest"
@@ -198,9 +198,9 @@ class TestSandboxLogic(unittest.IsolatedAsyncioTestCase):
         mock_start_supervisord.assert_called_once_with(mock_created_daytona_sandbox)
         self.assertEqual(result, mock_created_daytona_sandbox)
 
-    @patch('backend.sandbox.sandbox.logger')
-    @patch('backend.sandbox.sandbox.local_sandbox')
-    @patch('backend.sandbox.sandbox.use_daytona')
+    @patch('sandbox.sandbox.logger')
+    @patch('sandbox.sandbox.local_sandbox')
+    @patch('sandbox.sandbox.use_daytona')
     async def test_create_sandbox_local_path(self, mock_use_daytona_func, mock_ls_object, mock_logger):
         mock_use_daytona_func.return_value = False
 

--- a/backend/tests/test_run_agent_background.py
+++ b/backend/tests/test_run_agent_background.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 import uuid
 import json
 
-from backend.run_agent_background import run_agent_background, _cleanup_redis_instance_key, _cleanup_redis_response_list, update_agent_run_status # Import the target function
+from run_agent_background import run_agent_background, _cleanup_redis_instance_key, _cleanup_redis_response_list, update_agent_run_status # Import the target function
 from daytona_api_client.models.workspace_state import WorkspaceState
 from daytona_sdk import SessionExecuteRequest
 
@@ -31,10 +31,10 @@ langfuse_mock = MagicMock()
 langfuse_mock.trace = MagicMock(return_value=MagicMock(span=MagicMock(return_value=MagicMock(end=MagicMock()))))
 
 
-@patch('backend.run_agent_background.logger', logger_mock)
-@patch('backend.run_agent_background.redis', redis_mock)
-@patch('backend.run_agent_background.db', db_mock) # Patch the global db instance used by the actor
-@patch('backend.run_agent_background.langfuse', langfuse_mock)
+@patch('run_agent_background.logger', logger_mock)
+@patch('run_agent_background.redis', redis_mock)
+@patch('run_agent_background.db', db_mock) # Patch the global db instance used by the actor
+@patch('run_agent_background.langfuse', langfuse_mock)
 class TestRunAgentBackgroundCleanup(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
@@ -54,8 +54,8 @@ class TestRunAgentBackgroundCleanup(unittest.IsolatedAsyncioTestCase):
         self.mock_daytona_stop = AsyncMock()
 
         # Patch the specific functions/modules used by run_agent_background's finally block
-        self.patch_get_or_start_sandbox = patch('backend.sandbox.sandbox.get_or_start_sandbox', AsyncMock(return_value=self.mock_sandbox_instance))
-        self.patch_daytona = patch('backend.sandbox.sandbox.daytona', MagicMock(stop=self.mock_daytona_stop))
+        self.patch_get_or_start_sandbox = patch('sandbox.sandbox.get_or_start_sandbox', AsyncMock(return_value=self.mock_sandbox_instance))
+        self.patch_daytona = patch('sandbox.sandbox.daytona', MagicMock(stop=self.mock_daytona_stop))
         
         self.mock_get_or_start_sandbox = self.patch_get_or_start_sandbox.start()
         self.mock_daytona_client_for_stop = self.patch_daytona.start() # This mocks the 'daytona' object from sandbox.sandbox
@@ -76,7 +76,7 @@ class TestRunAgentBackgroundCleanup(unittest.IsolatedAsyncioTestCase):
 
     async def run_agent_to_finally(self, mock_run_agent_gen):
         """Helper to run the agent background task until the finally block is executed."""
-        with patch('backend.run_agent_background.run_agent', mock_run_agent_gen):
+        with patch('run_agent_background.run_agent', mock_run_agent_gen):
             await run_agent_background(
                 agent_run_id="test_agent_run_id",
                 thread_id="test_thread_id",

--- a/backend/tests/utils/scripts/test_delete_old_archived_sandboxes.py
+++ b/backend/tests/utils/scripts/test_delete_old_archived_sandboxes.py
@@ -10,7 +10,7 @@ import os
 # This assumes the test runner is initiated from the project root.
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
 
-from backend.utils.scripts.delete_old_archived_sandboxes import main as delete_script_main
+from utils.scripts.delete_old_archived_sandboxes import main as delete_script_main
 from daytona_api_client.models.workspace_state import WorkspaceState
 from daytona_sdk.sandbox import SandboxInfo, Sandbox # For creating mock objects
 
@@ -20,8 +20,8 @@ mock_logger = MagicMock()
 # This needs to target where 'logger' is *used*, not where it's defined, if they differ.
 # Assuming 'backend.utils.logger.logger' is the path if the script does 'from backend.utils.logger import logger'
 # Or if the script does 'from utils.logger import logger' and utils is in sys.path
-# The script uses 'from backend.utils.logger import logger'
-logger_patch_path = 'backend.utils.scripts.delete_old_archived_sandboxes.logger'
+# The script uses 'from utils.logger import logger'
+logger_patch_path = 'utils.scripts.delete_old_archived_sandboxes.logger'
 
 @patch(logger_patch_path, mock_logger) # Patch logger for all tests in this class
 class TestDeleteOldArchivedSandboxes(unittest.IsolatedAsyncioTestCase):
@@ -31,11 +31,11 @@ class TestDeleteOldArchivedSandboxes(unittest.IsolatedAsyncioTestCase):
         mock_logger.reset_mock()
 
         self.mock_daytona_client = AsyncMock()
-        self.patch_daytona_client = patch('backend.utils.scripts.delete_old_archived_sandboxes.daytona', self.mock_daytona_client)
+        self.patch_daytona_client = patch('utils.scripts.delete_old_archived_sandboxes.daytona', self.mock_daytona_client)
         self.patch_daytona_client.start() # Start patcher
 
         self.fixed_now = datetime(2023, 10, 31, 12, 0, 0, tzinfo=dt_timezone.utc)
-        self.patch_datetime_now = patch('backend.utils.scripts.delete_old_archived_sandboxes.datetime')
+        self.patch_datetime_now = patch('utils.scripts.delete_old_archived_sandboxes.datetime')
         self.mock_datetime = self.patch_datetime_now.start()
         self.mock_datetime.now.return_value = self.fixed_now
         self.mock_datetime.fromisoformat.side_effect = datetime.fromisoformat # Use real fromisoformat

--- a/backend/utils/scripts/delete_old_archived_sandboxes.py
+++ b/backend/utils/scripts/delete_old_archived_sandboxes.py
@@ -8,8 +8,8 @@ from datetime import datetime, timedelta, timezone as dt_timezone # Renamed to a
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
 
 from dotenv import load_dotenv
-from backend.sandbox.sandbox import daytona # Assuming daytona client is initialized here
-from backend.utils.logger import logger
+from sandbox.sandbox import daytona # Assuming daytona client is initialized here
+from utils.logger import logger
 from daytona_api_client.models.workspace_state import WorkspaceState # For state comparison
 from daytona_sdk.sandbox import SandboxInfo # For type hinting if needed
 


### PR DESCRIPTION
I corrected an `ImportError: attempted relative import beyond top-level package` in `backend/agentpress/tool_orchestrator.py` by changing `from ..utils.logger import logger` to `from utils.logger import logger`.

Additionally, I resolved potential `ModuleNotFoundError` issues by removing the `backend.` prefix from import statements in several files across the `backend` directory. This ensures that modules are imported directly from the top-level packages as expected by your application's execution context.

Files I affected by `backend.` prefix removal:
- backend/agentpress/task_planner.py
- backend/agentpress/thread_manager.py
- backend/agentpress/utils/message_assembler.py
- backend/tests/agent/test_run_detection.py
- backend/tests/agent/tools/test_python_tool.py
- backend/tests/agentpress/test_plan_executor.py
- backend/tests/agentpress/test_task_planner.py
- backend/tests/agentpress/test_task_state_manager.py
- backend/tests/sandbox/test_local_sandbox.py
- backend/tests/sandbox/test_sandbox_logic.py
- backend/tests/test_run_agent_background.py
- backend/tests/utils/scripts/test_delete_old_archived_sandboxes.py
- backend/utils/scripts/delete_old_archived_sandboxes.py