### PR TITLE
chore: Explicitly set mode for os.makedirs in logger

### DIFF
--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -87,7 +87,7 @@ def setup_logger(name: str = 'BACKEND') -> logging.Logger:
     app_specific_log_dir_path = "/app/runtime_logs/" # Explicit absolute path
     app_log_file_setup_success = False
     try:
-        os.makedirs(app_specific_log_dir_path, exist_ok=True)
+        os.makedirs(app_specific_log_dir_path, mode=0o777, exist_ok=True)
         # Check if directory is writable
         if not os.access(app_specific_log_dir_path, os.W_OK):
             # If not writable, raise an error to be caught by the except block


### PR DESCRIPTION
In `backend/utils/logger.py`, I set `mode=0o777` for `os.makedirs` when creating the application-specific log directory (`/app/runtime_logs/`).

This is a minor change to exhaust possible Python-side adjustments for file logging, although issues with logs not appearing on the host via Docker volumes are typically due to volume mapping configuration or host permissions.