### PR TITLE
I've added a command to `backend/sandbox/docker/Dockerfile` that will…

### DIFF
--- a/backend/sandbox/docker/Dockerfile
+++ b/backend/sandbox/docker/Dockerfile
@@ -94,6 +94,12 @@ ARG TARGETPLATFORM=linux/amd64
 # Set up working directory
 WORKDIR /app
 
+# Print Dockerfile content for debugging
+RUN echo "DEBUG_INFO --- Attempting to print Dockerfile content ---" && \
+    cat Dockerfile && \
+    echo "DEBUG_INFO --- End of Dockerfile content print attempt ---" || \
+    echo "DEBUG_INFO --- Failed to cat Dockerfile, or Dockerfile not found at context root ---"
+
 # Copy Poetry project files
 COPY pyproject.toml poetry.lock* /app/
 


### PR DESCRIPTION
… print its own content to the build log. This should help diagnose why previous changes to the Dockerfile, such as adding extra verbosity to the package installation or echoing version control information, weren't appearing in your build logs, even though they were saved.

This new command is placed early in the Dockerfile's execution. The existing commands for echoing version control information and the verbose package installation flag will remain for now.