### PR TITLE
Debug: Restore verbose poetry install and git info

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,8 +8,6 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-RUN echo "DEBUG_STEP_V5 --- This is backend/Dockerfile being executed --- Timestamp: $(date)"
-
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -26,7 +24,8 @@ COPY pyproject.toml poetry.lock* /app/
 
 # Install dependencies using Poetry
 RUN poetry cache clear . --all -n
-RUN poetry install --no-root --without dev --sync
+RUN echo "BUILD_INFO --- Branch: $(git rev-parse --abbrev-ref HEAD) --- Commit: $(git rev-parse HEAD) --- Timestamp: $(date)" || echo "BUILD_INFO --- Git info not available (backend/Dockerfile) --- Timestamp: $(date)"
+RUN poetry install --no-root --without dev --sync -vvv
 
 # Run Dramatiq check using poetry run
 RUN poetry run python -c "print('--- Docker Build Dramatiq Check ---'); import dramatiq; import dramatiq.middleware; print('Dramatiq version in Docker build:', dramatiq.__version__); print('Middleware path:', dramatiq.middleware.__file__); print('Middleware contents:', dir(dramatiq.middleware)); print('--- End Docker Build Dramatiq Check ---')"


### PR DESCRIPTION
Re-added the -vvv flag to 'poetry install' and the RUN command to echo git branch/commit information in backend/Dockerfile.

Removed the temporary DEBUG_STEP_V5 echo line.

This is to get detailed logs for diagnosing the poetry install failure.